### PR TITLE
Fix changelog markdown lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- markdownlint-disable no-duplicate-heading -->
+
 ## [0.1.5](https://github.com/joshka/betamax/compare/betamax-v0.1.4...betamax-v0.1.5) - 2026-06-12
 
 ### Other


### PR DESCRIPTION
## Summary

- allow duplicate generated changelog headings from release-plz using the descriptive markdownlint rule name

## Validation

- just lint-md
- just check