### PR TITLE
Add auto-merge required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,26 @@ jobs:
       - name: Check unused dependencies
         continue-on-error: true
         run: just udeps
+
+  required:
+    name: Required
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+      - package
+      - dependencies
+    if: ${{ always() }}
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          HAS_FAILED_JOB: >-
+            ${{
+              contains(needs.*.result, 'failure')
+              || contains(needs.*.result, 'cancelled')
+              || contains(needs.*.result, 'skipped')
+            }}
+        run: |
+          echo "$NEEDS_JSON"
+          test "$HAS_FAILED_JOB" = "false"


### PR DESCRIPTION
## Summary
- add an aggregate required CI job for repository rulesets and auto-merge
- fail the aggregate job when any required dependency fails, is cancelled, or is skipped

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'