### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      rust:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,39 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
+
+permissions: {}
 
 jobs:
   lint:
     name: Lint, docs, and validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
+          toolchain: stable
           components: clippy
 
       - name: Install nightly rustfmt
         run: rustup toolchain install nightly --component rustfmt
 
       - name: Install mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
 
@@ -35,7 +46,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Rust builds
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check formatting
         run: just fmt-check
@@ -58,6 +69,8 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -67,18 +80,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
 
       - name: Install mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
 
       - name: Cache Rust builds
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check workspace
         run: mise exec -- cargo check --workspace --all-targets
@@ -95,6 +112,8 @@ jobs:
   package:
     name: Package and smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -104,21 +123,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
 
       - name: Install nightly rustfmt
         run: rustup toolchain install nightly --component rustfmt
 
       - name: Install mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
 
       - name: Cache Rust builds
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Package crates
         run: just package
@@ -133,49 +156,55 @@ jobs:
     name: Dependency check (${{ matrix.name }})
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allow-failure }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: audit
-            tool: cargo-audit
+            tools: cargo-audit
             command: just audit
             allow-failure: false
           - name: features
-            tool: cargo-hack
+            tools: cargo-hack
             command: just feature-check
             allow-failure: false
           - name: minimal versions
-            tool: cargo-minimal-versions
+            tools: cargo-minimal-versions,cargo-hack
             command: just minimal-versions
             allow-failure: false
           - name: unused dependencies
-            tool: cargo-udeps
+            tools: cargo-udeps
             command: just udeps
             allow-failure: true
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
 
       - name: Install nightly Rust
         run: rustup toolchain install nightly
 
       - name: Install mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
 
       - name: Cache Rust builds
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install cargo maintenance tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
-          tool: ${{ matrix.tool }}
+          tool: ${{ matrix.tools }}
           fallback: none
 
       - name: Run dependency check
@@ -189,6 +218,7 @@ jobs:
       - test
       - package
       - dependencies
+      - zizmor
     if: ${{ always() }}
     steps:
       - name: Check required jobs
@@ -203,3 +233,18 @@ jobs:
         run: |
           echo "$NEEDS_JSON"
           test "$HAS_FAILED_JOB" = "false"
+
+  zizmor:
+    name: GitHub Actions security
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,10 @@ on:
       - "site/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -27,10 +31,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
 
@@ -45,7 +51,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: site/dist
 
@@ -63,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,20 +21,22 @@ jobs:
     steps:
       - &checkout
         name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
       - &install-rust
         name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
       - &install-mise
         name: Install mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           install: true
       - name: Run release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release
         env:
@@ -55,7 +57,7 @@ jobs:
       - *install-rust
       - *install-mise
       - name: Run release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Summary

This hardens the GitHub Actions workflows and adds ongoing workflow-security maintenance:

- Pin GitHub Actions to immutable commit SHAs.
- Keep exact semver comments for actions that publish exact release tags so Dependabot can update SHA pins without `zizmor` fighting moving major tags during cooldown windows.
- Add `zizmor-action` to CI in Advanced Security mode so findings are uploaded to code scanning.
- Configure Dependabot grouped weekly updates for GitHub Actions and Cargo dependencies with a 7-day cooldown.
- Add explicit least-privilege `permissions` blocks and disable checkout credential persistence.
- Add workflow-level concurrency cancellation for CI and Docs so new pushes stop stale PR runs.

## Findings Addressed

The initial local `zizmor` audit found three classes of workflow issues:

- `unpinned-uses`: all actions were referenced by mutable tags such as `v4`, `v2`, or `stable`.
- `excessive-permissions`: `ci.yml` relied on default token permissions.
- `artipacked`: `actions/checkout` did not set `persist-credentials: false`.

The first CI run surfaced an additional online-audit issue that the offline local run did not catch: `ref-version-mismatch`. A few pinned SHAs pointed at annotated tag objects rather than the underlying commits. Those are now dereferenced to the commit SHAs that `zizmor` expects.

## Dependabot Strategy

Dependabot is configured for grouped weekly updates with a 7-day cooldown for both `github-actions` and `cargo`.

The cooldown matters because broad moving comments like `# v4` or `# v2` can advance upstream before Dependabot opens an update PR. That makes the human-readable comment stale even when the pinned SHA is intentionally unchanged. Exact comments such as `# v4.3.1` describe the immutable commit being run, and Dependabot can update both the SHA and comment together when it eventually opens a grouped update.

## Toolchain Choice

This follows the `tui-widgets` pattern for `dtolnay/rust-toolchain`: keep the action implementation pinned by SHA, but leave the comment as `# master` and select the Rust channel through action inputs.

That is intentional because `dtolnay/rust-toolchain` does not provide the same exact semver release-tag shape as the other actions. Replacing it with raw `rustup toolchain install ...` was considered, but rejected because it diverged from the established workflow pattern and made the Rust setup less consistent across repositories.

## Advanced Security Mode

`zizmor-action` now runs in its default Advanced Security mode. The job grants:

- `security-events: write` for SARIF/code scanning upload.
- `contents: read` because the job checks out the repository.

`actions: read` was considered after checking the upstream docs, but it is only needed for private or internal repositories. This repository is public, so that permission was left out.

## Considered And Rejected

- Using mutable major tags directly: rejected because `zizmor` requires immutable pins.
- Using SHA pins with broad comments like `# v4`: rejected because moving comments go stale during Dependabot cooldowns and trigger `ref-version-mismatch`.
- Replacing `dtolnay/rust-toolchain` with direct `rustup` commands: rejected in favor of matching the `tui-widgets` pinned-action pattern.
- Running `zizmor-action` with `advanced-security: false`: rejected because code scanning gives stateful triage and matches the upstream recommended mode.
- Granting `actions: read` to the zizmor job: rejected because this is a public repository and the documented need is private/internal-only.

## CI Notes

A previous CI run failed because the `minimal versions` matrix installed only `cargo-minimal-versions`, while the `just minimal-versions` recipe also invokes `cargo hack`. The matrix now installs both tools for that case.

CI and Docs now use `concurrency` with `cancel-in-progress: true`, grouped by workflow and ref. This cancels stale runs after a new push to the same PR branch without changing the existing release-plz behavior, which intentionally keeps `cancel-in-progress: false`.

## Validation

- `GH_TOKEN=$(gh auth token) zizmor --no-progress --no-exit-codes .`
- `actionlint`