### PR TITLE
Improve repository maintenance setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report reproducible Betamax behavior that looks incorrect.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Include the smallest tape, command, or repository state that reproduces it.
+      placeholder: |
+        ```sh
+        betamax run example.tape
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include versions and platform details.
+      placeholder: |
+        betamax --version
+        rustc --version
+        uname -a
+        echo "$SHELL"
+    validations:
+      required: true
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Artifacts
+      description: Attach or describe screenshots, state JSON, logs, or generated media if useful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/joshka/betamax/security
+    about: Report suspected vulnerabilities privately instead of opening a public issue.
+  - name: Documentation
+    url: https://www.joshka.net/betamax/
+    about: Check the documentation site for tape syntax and command behavior.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest focused behavior, syntax, output, or documentation improvements.
+title: "Feature: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow is hard or unsupported today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the behavior or API you want Betamax to provide.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: What workarounds or other designs did you consider?
+  - type: checkboxes
+    id: docs
+    attributes:
+      label: Documentation impact
+      options:
+        - label: This would need tape reference, examples, or docs site updates.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Pull Request
+
+## Summary
+
+Describe the user-visible behavior or maintainer-facing change.
+
+## Validation
+
+List the commands run, or explain why a narrower check was sufficient.
+
+```sh
+just check
+```
+
+## Notes
+
+Mention docs, examples, release notes, or follow-up work when relevant.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install nightly rustfmt
         run: rustup toolchain install nightly --component rustfmt
 
+      - name: Install beta clippy
+        run: rustup toolchain install beta --component clippy
+
       - name: Install mise tools
         uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
@@ -53,6 +56,9 @@ jobs:
 
       - name: Check clippy
         run: just clippy
+
+      - name: Check beta clippy
+        run: just clippy-beta
 
       - name: Check documentation builds
         run: just doc
@@ -162,9 +168,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: audit
-            tools: cargo-audit
-            command: just audit
+          - name: dependency policy
+            tools: cargo-deny
+            command: just dependency-policy
             allow-failure: false
           - name: features
             tools: cargo-hack

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "24 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze Rust
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: rust
+          build-mode: none
+          queries: +security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Code Of Conduct
+
+Betamax is maintained as a small technical project. Participation should stay focused, respectful,
+and useful to the work.
+
+Expected behavior:
+
+- assume good intent while still being direct about technical issues;
+- keep criticism specific to code, documentation, behavior, or project decisions;
+- respect maintainer time by providing reproducible examples and clear context;
+- avoid harassment, personal attacks, discriminatory language, and repeated off-topic demands.
+
+The maintainer may edit, hide, lock, or remove comments and issues that make the project harder to
+maintain. Serious or repeated violations may result in blocked participation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,10 @@ mise install
 ```
 
 The checked-in `.mise.toml` installs `just`, `markdownlint-cli2`, Node, and Zig. Zig is present for
-native dependency work around Ghostty tooling. Rust itself is managed with `rustup`; the workspace
-currently declares Rust `1.93` in `Cargo.toml`.
+native dependency work around Ghostty tooling. Rust itself is managed with `rustup`.
+
+The workspace `rust-version` is a compatibility floor, not a separately tested MSRV lane. It
+should move only when Betamax code or dependency requirements need a newer compiler.
 
 Rust formatting uses nightly rustfmt because `rustfmt.toml` enables unstable formatting options:
 
@@ -50,15 +52,15 @@ Run the same broad check used by CI:
 just check
 ```
 
-This runs formatting, tests, doctests, documentation generation, Markdown linting, and tape
-validation. For release-oriented changes, run the larger check:
+This runs nightly formatting, stable and beta clippy, tests, doctests, documentation generation,
+Markdown linting, and tape validation. For release-oriented changes, run the larger check:
 
 ```sh
 just release-check
 ```
 
-`just release-check` also checks direct dependency freshness, direct minimal versions, packaging,
-install smoke testing, and rendering the basic smoke tape.
+`just release-check` also checks dependency policy, direct dependency freshness, direct minimal
+versions, packaging, install smoke testing, and rendering the basic smoke tape.
 
 ## Useful Checks
 
@@ -67,6 +69,8 @@ Use narrower commands while iterating:
 ```sh
 just fmt
 just fmt-check
+just clippy
+just clippy-beta
 just test
 just doc-test
 just doc
@@ -78,6 +82,7 @@ just smoke
 Dependency maintenance has dedicated recipes:
 
 ```sh
+just dependency-policy
 just outdated
 just minimal-versions
 ```
@@ -85,7 +90,7 @@ just minimal-versions
 If those checks require missing Cargo subcommands, install them with Cargo:
 
 ```sh
-cargo install cargo-outdated cargo-minimal-versions cargo-hack --locked
+cargo install cargo-deny cargo-outdated cargo-minimal-versions cargo-hack --locked
 ```
 
 ## Tape Behavior

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ workflow and state snapshot format.
 - [Differences From VHS][vhs-differences]
 - [Contributing](CONTRIBUTING.md)
 - [Development](docs/development.md)
+- [Security Policy](SECURITY.md)
+- [Support](SUPPORT.md)
 
 The Starlight docs site lives under `site/` and can be run locally with:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the latest released Betamax version and `main`. Older releases may receive
+fixes when the impact and upgrade path justify the extra maintenance.
+
+## Reporting A Vulnerability
+
+Please do not report suspected vulnerabilities in public issues.
+
+Use GitHub private vulnerability reporting if it is available on the repository. Otherwise, contact
+the maintainer through the email address on the maintainer's GitHub or crates.io profile.
+
+Include enough detail to reproduce and assess the issue:
+
+- affected Betamax version or commit;
+- platform and shell;
+- tape file or command input involved;
+- expected impact;
+- whether the issue requires untrusted input, a malicious repository, or local access.
+
+The maintainer will acknowledge actionable reports, investigate the impact, and coordinate a fix
+and release when the issue is valid.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,14 @@
+# Support
+
+Use the documentation site first for command behavior and tape syntax:
+
+- [Betamax documentation](https://www.joshka.net/betamax/)
+- [Tape reference](https://www.joshka.net/betamax/reference/tape-reference/)
+- [Terminal testing](https://www.joshka.net/betamax/testing/terminal-testing/)
+
+Use GitHub issues for reproducible bugs, missing documentation, and focused feature requests.
+Include the Betamax version, platform, shell, tape file, command output, and generated artifacts
+when they help explain the problem.
+
+Please report suspected security vulnerabilities through the process in
+[SECURITY.md](SECURITY.md), not public issues.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,8 +18,22 @@ requires nightly rustfmt:
 just fmt-check
 ```
 
+Clippy runs on stable and beta. Stable is the baseline, and beta catches new lints before they
+reach the next stable release:
+
+```sh
+just clippy
+just clippy-beta
+```
+
 Markdown linting uses [.markdownlint-cli2.yaml](../.markdownlint-cli2.yaml). It enforces aligned
 table columns via `MD060/table-column-style` and ignores table rows for line-length checks.
+
+## Rust Version Policy
+
+The workspace `rust-version` is a compatibility floor, not a separately tested MSRV lane. It should
+move only when Betamax code or dependency requirements need a newer compiler. Routine CI follows
+the current stable compiler, with beta clippy used as an early warning for upcoming lint changes.
 
 ## Checks
 
@@ -33,6 +47,12 @@ just lint-md
 just validate
 just docs-site-check
 just docs-site-build
+```
+
+Dependency policy is enforced with cargo-deny:
+
+```sh
+just dependency-policy
 ```
 
 Release-oriented checks are kept in `just` so local and CI behavior stay aligned:

--- a/justfile
+++ b/justfile
@@ -15,6 +15,9 @@ test:
 clippy:
     mise exec -- cargo clippy --workspace --all-targets -- -D warnings
 
+clippy-beta:
+    mise exec -- cargo +beta clippy --workspace --all-targets -- -D warnings
+
 doc-test:
     mise exec -- cargo test --workspace --doc
 
@@ -30,8 +33,8 @@ outdated:
 minimal-versions:
     mise exec -- cargo minimal-versions --direct --workspace check
 
-audit:
-    mise exec -- cargo audit
+dependency-policy:
+    mise exec -- cargo deny check advisories licenses bans sources
 
 feature-check:
     mise exec -- cargo hack check --workspace --all-targets
@@ -88,6 +91,6 @@ install-smoke:
     CARGO_HOME="$tmp/cargo-home" mise exec -- cargo install --path crates/betamax --locked --root "$tmp/install"
     "$tmp/install/bin/betamax" --version
 
-check: fmt-check clippy test doc-test doc lint-md validate docs-site-check docs-site-build
+check: fmt-check clippy clippy-beta test doc-test doc lint-md validate docs-site-check docs-site-build
 
-release-check: check audit feature-check outdated minimal-versions package install-smoke smoke
+release-check: check dependency-policy feature-check outdated minimal-versions package install-smoke smoke


### PR DESCRIPTION
## Summary

- add security, support, code of conduct, issue templates, and a PR template
- add CodeQL Rust code scanning with pinned actions
- replace the cargo-audit maintenance path with cargo-deny advisory, license, ban, and source policy checks
- document the Rust version policy and stable/beta clippy workflow
- link the new support and security docs from the README

## Repository settings updated

- set the repository description, homepage, and topics
- enabled secret scanning and push protection
- enabled private vulnerability reporting
- set default GitHub Actions token permissions to read-only

## Follow-up

GitHub Pages HTTPS enforcement could not be enabled yet. The API returned `The certificate does not exist yet (HTTP 404)`, and Pages still reports `https_enforced: false`, so the Pages/domain certificate needs to be provisioned before enforcement can be turned on.

## Validation

```sh
just dependency-policy
just lint-md
python3 - <<'PY'
from pathlib import Path
import yaml
for path in sorted(Path('.github').glob('**/*.yml')):
    with path.open() as f:
        yaml.safe_load(f)
    print(path)
PY
just --summary
```
