### PR TITLE
Canonicalize docs base route

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,15 +1,26 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
+const base = '/betamax';
+const canonicalBasePathScript = [
+  `if (location.pathname === '${base}') {`,
+  `  location.replace('${base}/' + location.search + location.hash);`,
+  '}',
+].join('\n');
+
 export default defineConfig({
   site: 'https://www.joshka.net',
-  base: '/betamax',
+  base,
   integrations: [
     starlight({
       title: 'Betamax',
       description: 'Rust-first terminal captures, GIFs, screenshots, and terminal snapshots.',
       customCss: ['./src/styles/custom.css'],
       head: [
+        {
+          tag: 'script',
+          content: canonicalBasePathScript,
+        },
         {
           tag: 'meta',
           attrs: {

--- a/site/src/content/docs/reference/development.mdx
+++ b/site/src/content/docs/reference/development.mdx
@@ -32,5 +32,16 @@ just docs-site-check
 just docs-site-build
 ```
 
+## Internal Docs Links
+
+The docs site is published under Astro's `/betamax` base path. Starlight-generated navigation,
+sidebar, and pagination links are already base-aware, but links authored directly in MDX are emitted
+as written.
+
+Use normal relative Markdown links between docs pages. The site config canonicalizes the slashless
+base route, `/betamax`, to `/betamax/` before users can follow those links. Without that redirect,
+links such as `./quick-start/` would resolve to `/quick-start/` from `/betamax` instead of staying
+under `/betamax/`.
+
 Releases are managed by release-plz and crates.io Trusted Publishing. The release workflow installs
 mise tools because package verification builds `libghostty-vt-sys`, which requires Zig.


### PR DESCRIPTION
## Summary

- canonicalize the slashless docs base path before relative links can resolve outside /betamax
- document the relative-link assumption for the GitHub Pages and local docs setup

## Validation

- pnpm docs:build
- pnpm docs:check
- pnpm exec markdownlint-cli2 site/src/content/docs/reference/development.mdx
- verified in the in-app browser that /betamax becomes /betamax/ and Quick Start resolves to /betamax/quick-start/
