### PR TITLE
Add docs overview page

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -64,7 +64,7 @@ export default defineConfig({
         {
           label: 'Start',
           items: [
-            { label: 'Overview', slug: 'index' },
+            { label: 'Overview', slug: 'overview' },
             { label: 'Quick Start', slug: 'quick-start' },
             { label: 'Examples', slug: 'examples' },
           ],

--- a/site/src/content/docs/authoring/outputs.mdx
+++ b/site/src/content/docs/authoring/outputs.mdx
@@ -51,7 +51,8 @@ sudo apt-get update
 sudo apt-get install ffmpeg
 ```
 
-Use `Require ffmpeg` if the tape should fail before doing any other work:
+Use [`Require ffmpeg`](../../reference/tape-reference/#require-program) if the tape should fail
+before doing any other work:
 
 ```text
 Output examples/output/demo.mp4
@@ -71,5 +72,6 @@ Screenshot target/snapshots/ready.png
 State target/snapshots/ready.json
 ```
 
-The screenshot preserves the decorated visual frame. The state JSON preserves terminal text and
-styles in a compact comparison format.
+The [`Screenshot`](../../reference/tape-reference/#screenshot-pathpng) preserves the decorated
+visual frame. The [`State`](../../reference/tape-reference/#state-pathjson) JSON preserves terminal
+text and styles in a compact comparison format.

--- a/site/src/content/docs/authoring/tape-files.mdx
+++ b/site/src/content/docs/authoring/tape-files.mdx
@@ -3,9 +3,11 @@ title: Tape Files
 description: How Betamax parses, validates, and executes terminal capture scripts.
 ---
 
-A tape is a small script that describes one terminal session. It names output artifacts, configures
-the terminal, starts a shell in a PTY, sends text and keys, waits for stable terminal states, and
-optionally writes checkpoint screenshots or state JSON.
+A tape is a small script that describes one terminal session. It names
+[`Output`](../../reference/tape-reference/#output-path) artifacts, configures the terminal, starts a
+shell in a PTY, sends text and keys, waits for stable terminal states, and optionally writes
+checkpoint [`Screenshot`](../../reference/tape-reference/#screenshot-pathpng) or
+[`State`](../../reference/tape-reference/#state-pathjson) files.
 
 Start here for authoring concepts. Use the [Tape Reference](../../reference/tape-reference/) for
 the exact command surface and [Examples](../../examples/) for copyable tapes.
@@ -30,11 +32,16 @@ Wait+Screen "hello"
 
 Most tapes follow this order:
 
-1. Declare `Output` files.
-1. Declare `Require` checks for external commands used by the tape.
-1. Apply `Env` and `Set` startup configuration.
-1. Run terminal actions such as `Type`, key presses, waits, screenshots, and state captures.
-1. Hide trailing cleanup with `Hide`, then type `exit` if the shell should close cleanly.
+1. Declare [`Output`](../../reference/tape-reference/#output-path) files.
+1. Declare [`Require`](../../reference/tape-reference/#require-program) checks for external
+   commands used by the tape.
+1. Apply [`Env`](../../reference/tape-reference/#env-key-value) and
+   [`Set`](../../reference/tape-reference/#set-name-value) startup configuration.
+1. Run terminal actions such as [`Type`](../../reference/tape-reference/#typeduration-text), key
+   presses, [waits](../../reference/tape-reference/#waitduration-regextext), screenshots, and state
+   captures.
+1. Hide trailing cleanup with [`Hide`](../../reference/tape-reference/#hide), then type `exit` if
+   the shell should close cleanly.
 
 Startup commands must appear before runtime commands. This is intentional: Betamax needs to know
 the shell argv, terminal dimensions, theme, environment, and output requirements before it starts
@@ -71,15 +78,17 @@ Enter
 Wait+Screen "test result:"
 ```
 
-Use `Wait+Line` or bare `Wait` for prompts. Use `Wait+Screen` for command output, full-screen TUIs,
-and text that may not be on the cursor line. Use regex waits when the output contains changing
-numbers, paths, durations, or identifiers.
+Use [`Wait+Line`](../../reference/tape-reference/#waitlineduration-regextext) or bare
+[`Wait`](../../reference/tape-reference/#waitduration-regextext) for prompts. Use
+[`Wait+Screen`](../../reference/tape-reference/#waitscreenduration-regextext) for command output,
+full-screen TUIs, and text that may not be on the cursor line. Use regex waits when the output
+contains changing numbers, paths, durations, or identifiers.
 
 ## Hidden Work
 
-`Hide` and `Show` are visibility controls, not execution controls. Hidden commands still run in the
-PTY, still update terminal state, and can still be waited on. They simply do not append frames to
-animated outputs.
+[`Hide`](../../reference/tape-reference/#hide) and [`Show`](../../reference/tape-reference/#show)
+are visibility controls, not execution controls. Hidden commands still run in the PTY, still update
+terminal state, and can still be waited on. They simply do not append frames to animated outputs.
 
 ```text
 Hide
@@ -93,13 +102,15 @@ Enter
 Wait+Screen "Ready"
 ```
 
-`Show` immediately captures the current terminal frame. That avoids a visible flicker from a hidden
-shell prompt to the useful output.
+[`Show`](../../reference/tape-reference/#show) immediately captures the current terminal frame. That
+avoids a visible flicker from a hidden shell prompt to the useful output.
 
 ## Outputs During A Tape
 
-`Output` describes final artifacts written after execution. `Screenshot` and `State` write
-checkpoint artifacts immediately at their position in the tape.
+[`Output`](../../reference/tape-reference/#output-path) describes final artifacts written after
+execution. [`Screenshot`](../../reference/tape-reference/#screenshot-pathpng) and
+[`State`](../../reference/tape-reference/#state-pathjson) write checkpoint artifacts immediately at
+their position in the tape.
 
 ```text
 Wait+Screen "Saved profile"
@@ -114,7 +125,8 @@ PNG or checkpoint screenshot so reviewers can inspect one frame without opening 
 
 For common shells such as `bash`, `zsh`, and `fish`, Betamax starts a clean recording-oriented
 environment where possible. The default prompt behavior aims for VHS-like output: a simple `>`
-prompt rather than host-specific prompts such as `bash-5.3$`.
+prompt rather than host-specific prompts such as `bash-5.3$`. See
+[Differences From VHS](../../reference/vhs-differences/) for the compatibility boundary.
 
 Set `Shell` explicitly when a tape depends on shell syntax:
 

--- a/site/src/content/docs/authoring/themes.mdx
+++ b/site/src/content/docs/authoring/themes.mdx
@@ -5,7 +5,8 @@ description: Ghostty themes, window borders, padding, prompt defaults, and layou
 
 Betamax uses Ghostty-style theme files to map terminal color indexes and named colors into rendered
 RGB values. It searches user Ghostty theme directories first, then the copied themes bundled with
-`betamax-core`.
+`betamax-core`. See [Differences From VHS](../../reference/vhs-differences/) for the larger
+Ghostty-first architecture.
 
 ```sh
 betamax themes
@@ -88,7 +89,8 @@ Set CursorBlink false
 
 ## Current Theme Boundary
 
-Betamax applies the selected theme in its Rust renderer. The `libghostty-vt` terminal parser is not
-initialized with the selected palette yet, which mostly matters for future work where parser state
-may expose palette-aware data directly. The renderer path used for GIFs, PNGs, videos, and state
-style serialization uses Betamax's loaded theme.
+Betamax applies the selected theme in its Rust renderer. The
+[`libghostty-vt`](../../reference/vhs-differences/) terminal parser is not initialized with the
+selected palette yet, which mostly matters for future work where parser state may expose
+palette-aware data directly. The renderer path used for GIFs, PNGs, videos, and state style
+serialization uses Betamax's loaded theme.

--- a/site/src/content/docs/examples.mdx
+++ b/site/src/content/docs/examples.mdx
@@ -4,7 +4,8 @@ description: Small tapes that exercise the core Betamax behavior.
 ---
 
 The repository examples are intentionally small. They are smoke tests for core behavior and
-copyable starting points for your own tapes. Render all examples from a checkout with:
+copyable starting points for your own [tapes](../authoring/tape-files/). Render all examples from a
+checkout with:
 
 ```sh
 scripts/render-examples.sh
@@ -53,24 +54,25 @@ updates terminal state, but the animation starts only when `Show` reveals the pr
 
 ![Ghostty theme Betamax GIF](https://github.com/joshka/betamax/releases/download/readme-assets/themes.gif)
 
-`themes.tape` shows ANSI colors mapped through a bundled Ghostty theme. Use `betamax themes` to
-list the names available to `Set Theme`.
+`themes.tape` shows ANSI colors mapped through a bundled [Ghostty theme](../authoring/themes/).
+Use [`betamax themes`](../authoring/themes/) to list the names available to `Set Theme`.
 
 ### Video
 
 ![Video output Betamax GIF](https://github.com/joshka/betamax/releases/download/readme-assets/video.gif)
 
 `video.tape` writes GIF, MP4, and WebM from one capture. The GIF is encoded in process; MP4 and
-WebM are handed to `ffmpeg`.
+WebM are handed to [ffmpeg](../authoring/outputs/#video-encoding).
 
 ## Example Patterns
 
 Use `examples/outputs.tape` when checking artifact behavior. It writes a GIF, a PNG, final state
 JSON, a PNG frame directory, a checkpoint screenshot, and checkpoint state JSON.
 
-Use `examples/scrollback.tape` and `examples/text-styles.tape` when evaluating terminal testing.
-Together they exercise the parts of state JSON that matter for snapshot tests: viewport text,
-scrollback text, default style, non-default style table entries, and styled spans.
+Use `examples/scrollback.tape` and `examples/text-styles.tape` when evaluating
+[terminal testing](../testing/terminal-testing/). Together they exercise the parts of
+[state JSON](../testing/state-json/) that matter for snapshot tests: viewport text, scrollback text,
+default style, non-default style table entries, and styled spans.
 
 Use `examples/waits.tape` when debugging timing. It shows the three wait targets and a custom
 `WaitPattern`, which is usually preferable to adding sleeps.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -11,8 +11,9 @@ template: splash
       <img src="/betamax/assets/betamax-logo-lockup.png" alt="Betamax" loading="eager" />
     </h1>
     <div class="betamax-tagline">
-      VHS-style GIFs, screenshots, videos, and terminal snapshots without a browser, terminal
-      server, xterm.js, or ttyd process.
+      <a href="./reference/vhs-differences/">VHS-style</a> GIFs, screenshots, videos, and terminal
+      snapshots without a browser, terminal server, <a href="https://xtermjs.org/">xterm.js</a>,
+      or <a href="https://github.com/tsl0922/ttyd">ttyd</a> process.
     </div>
     <div class="betamax-actions">
       <a class="betamax-button betamax-button-primary" href="./quick-start/">Quick Start →</a>
@@ -29,9 +30,10 @@ template: splash
   </a>
 </section>
 
-Betamax reads tape files, runs commands in a real PTY, feeds terminal output through
-`libghostty-vt`, rasterizes frames in process with `cosmic-text` and `swash`, and writes artifacts
-for documentation or tests.
+Betamax reads <a href="./authoring/tape-files/">tape files</a>, runs commands in a real PTY, feeds
+terminal output through <a href="./reference/vhs-differences/">libghostty-vt</a>, rasterizes frames
+in process with <a href="https://github.com/pop-os/cosmic-text">cosmic-text</a> and
+<a href="https://github.com/dfrg/swash">swash</a>, and writes artifacts for documentation or tests.
 
 <div class="feature-grid">
   <section>
@@ -49,8 +51,8 @@ for documentation or tests.
     <h2>Terminal Testing</h2>
     <div class="bm-stripes" aria-hidden="true"></div>
     <p>
-      Wait for text, capture terminal state, and compare viewport, scrollback, and style spans in
-      snapshot tests.
+      <a href="./testing/terminal-testing/">Wait for text</a>, capture terminal state, and compare
+      viewport, scrollback, and style spans in snapshot tests.
     </p>
     <footer>
       <span>Test</span>
@@ -65,7 +67,10 @@ for documentation or tests.
   <section>
     <h2>Ghostty-Based Parsing</h2>
     <div class="bm-stripes" aria-hidden="true"></div>
-    <p>Terminal output is interpreted by `libghostty-vt`, with copied Ghostty themes by name.</p>
+    <p>
+      Terminal output is interpreted by <a href="./reference/vhs-differences/">libghostty-vt</a>,
+      with copied <a href="./authoring/themes/">Ghostty themes</a> by name.
+    </p>
     <footer>
       <span>Parser</span>
       <svg class="bm-meter" viewBox="0 0 72 14" aria-hidden="true">
@@ -82,8 +87,8 @@ for documentation or tests.
     <h2>Small & Focused</h2>
     <div class="bm-stripes" aria-hidden="true"></div>
     <p>
-      No xterm.js, no browser, no terminal server, no ttyd process. MP4 and WebM use `ffmpeg` only
-      for video encoding.
+      No xterm.js, no browser, no terminal server, no ttyd process. MP4 and WebM use
+      <a href="./authoring/outputs/#video-encoding">ffmpeg</a> only for video encoding.
     </p>
     <footer><span>Arch</span><span class="bm-chipset"><kbd class="hot">Min</kbd></span></footer>
   </section>
@@ -92,6 +97,10 @@ for documentation or tests.
 ## Where To Go Next
 
 <nav class="next-panel" aria-label="Where to go next">
+  <a href="./overview/">
+    <span>Overview</span>
+    <p>Understand the capture model, output types, and main docs paths.</p>
+  </a>
   <a href="./quick-start/">
     <span>Quick Start</span>
     <p>Get Betamax running in minutes.</p>

--- a/site/src/content/docs/overview.mdx
+++ b/site/src/content/docs/overview.mdx
@@ -1,0 +1,118 @@
+---
+title: Overview
+description: Betamax's capture model, output types, and main documentation paths.
+---
+
+Betamax turns [tape files][tape-files] into terminal artifacts for documentation and tests. A tape
+describes one terminal session: outputs, requirements, shell settings, typed text, key presses,
+waits, screenshots, and state snapshots.
+
+The runtime starts a real PTY, feeds terminal bytes into [`libghostty-vt`][vhs-differences],
+renders frames in process with [cosmic-text][cosmic-text] and [swash][swash], and writes the
+requested artifacts. GIF, PNG, screenshot, state JSON, and frame outputs stay inside the Rust
+process. MP4 and WebM output uses [ffmpeg][video-encoding] as the video encoder.
+
+Betamax follows the common [VHS][vhs-differences] tape-authoring shape, but it keeps a smaller
+Ghostty-first architecture. It does not start a browser, terminal server, `xterm.js`, or `ttyd`;
+does not implement VHS's `serve`, `record`, or `publish` workflows; and parses `Source` without
+executing it.
+
+## Output Types
+
+The same tape model can produce documentation media, review artifacts, and terminal-testing
+snapshots:
+
+| Output                         | Use case                                                              |
+| ------------------------------ | --------------------------------------------------------------------- |
+| GIF                            | README demos, release notes, and docs pages                           |
+| PNG                            | Final-frame previews and static screenshots                           |
+| MP4 and WebM                   | Video embeds when GIF size or playback quality matters                |
+| Screenshot checkpoints         | Intermediate frames at meaningful moments in a tape                   |
+| [State JSON][state-json]       | Terminal-testing snapshots with viewport, scrollback, and style spans |
+| Frame directories              | Debugging and custom post-processing                                  |
+
+Final [`Output`][output-command] artifacts are written after the tape finishes.
+[`Screenshot`][screenshot-command] and [`State`][state-command] commands write checkpoint artifacts
+at their position in the tape.
+
+## Tape Model
+
+Most tapes have the same shape:
+
+1. [`Output`][output-command] commands declare final artifacts.
+1. [`Require`][require-command] commands check external programs before terminal work starts.
+1. [`Set`][set-command] and [`Env`][env-command] commands configure the shell, environment,
+   dimensions, theme, timing, and frame styling.
+1. Runtime commands type text, press keys, paste content, wait for terminal state, hide or reveal
+   frame capture, and write checkpoint artifacts.
+
+[Wait commands][wait-commands] match the terminal state reported by `libghostty-vt`. `Wait` and
+`Wait+Line` match the current cursor line; `Wait+Screen` matches visible viewport text. That makes a
+tape depend on terminal output instead of a fixed sleep whenever the next frame has an observable
+condition.
+
+## Documentation Captures
+
+[Quick Start][quick-start] covers installation and the first rendered tape. [Tape Files][tape-files]
+explains tape structure, tokenization, waits, hidden work, outputs, and shell defaults.
+[Examples][examples] maps each checked-in tape to the behavior it demonstrates.
+
+[Generated Media Storage][generated-media] covers where rendered files belong when a repository
+needs stable README media, review artifacts, CI outputs, or web-hosted documentation assets.
+
+## Output And Styling Reference
+
+[Outputs][outputs] documents output commands, checkpoint behavior, frame directories, and the
+`ffmpeg` boundary for video files. [Themes And Styling][themes] covers copied Ghostty themes, theme
+lookup, terminal dimensions, font size, padding, margin, fill, window bars, border radius,
+framerate, and playback speed.
+
+The [Tape Reference][tape-reference] is the exact command surface: supported outputs, settings,
+defaults, runtime commands, ignored VHS commands, and CLI subcommands.
+
+## Terminal Testing
+
+Betamax can act as a terminal-testing harness for CLIs and TUIs. A test tape can run an interactive
+program, wait for expected text, capture screenshots at checkpoints, and write state JSON for
+snapshot assertions.
+
+[Terminal Testing][terminal-testing] explains the workflow. [State JSON][state-json] documents the
+snapshot format: viewport rows, optional scrollback, cursor position, terminal dimensions, default
+style, and non-default style spans.
+
+## Compatibility
+
+Betamax currently supports macOS and Linux. Windows is not supported because the upstream
+`libghostty-vt-sys` native build does not support Windows.
+
+Video output requires [ffmpeg][video-encoding] on `PATH`. Other output formats do not require an
+external encoder.
+
+## Next Pages
+
+- [Quick Start][quick-start] installs Betamax and renders a first tape.
+- [Examples][examples] shows each checked-in tape and the behavior it demonstrates.
+- [Tape Reference][tape-reference] documents every command, setting, default, and CLI option.
+- [Differences From VHS][vhs-differences] explains compatibility boundaries for users familiar
+  with VHS.
+
+[cosmic-text]: https://github.com/pop-os/cosmic-text
+[examples]: ../examples/
+[generated-media]: ../authoring/generated-media/
+[env-command]: ../reference/tape-reference/#env-key-value
+[outputs]: ../authoring/outputs/
+[output-command]: ../reference/tape-reference/#output-path
+[quick-start]: ../quick-start/
+[require-command]: ../reference/tape-reference/#require-program
+[screenshot-command]: ../reference/tape-reference/#screenshot-pathpng
+[set-command]: ../reference/tape-reference/#set-name-value
+[state-json]: ../testing/state-json/
+[state-command]: ../reference/tape-reference/#state-pathjson
+[swash]: https://github.com/dfrg/swash
+[tape-files]: ../authoring/tape-files/
+[tape-reference]: ../reference/tape-reference/
+[terminal-testing]: ../testing/terminal-testing/
+[themes]: ../authoring/themes/
+[video-encoding]: ../authoring/outputs/#video-encoding
+[vhs-differences]: ../reference/vhs-differences/
+[wait-commands]: ../reference/tape-reference/#waitduration-regextext

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -4,7 +4,7 @@ description: Install Betamax and render your first tape.
 ---
 
 Betamax currently supports macOS and Linux. Windows is not supported because the upstream
-`libghostty-vt-sys` native build does not support Windows.
+[`libghostty-vt-sys`](../reference/vhs-differences/) native build does not support Windows.
 
 ## Install
 
@@ -13,7 +13,7 @@ cargo install betamax --locked
 ```
 
 GIF, PNG, screenshot, and state JSON outputs are written in process. MP4 and WebM output require
-`ffmpeg` on `PATH`:
+[ffmpeg](../authoring/outputs/#video-encoding) on `PATH`:
 
 ```sh
 # macOS
@@ -37,14 +37,15 @@ with:
 betamax run demo.tape
 ```
 
-Append an extra output from the CLI without editing the tape:
+Append an extra [`Output`](../reference/tape-reference/#output-path) from the CLI without editing
+the tape:
 
 ```sh
 betamax run demo.tape --output target/demo.png
 ```
 
-The output path is appended as another `Output` command. It does not replace outputs already in the
-tape.
+The output path is appended as another [`Output`](../reference/tape-reference/#output-path)
+command. It does not replace outputs already in the tape.
 
 ## Validate Tapes
 
@@ -56,7 +57,8 @@ betamax validate "examples/*.tape"
 ```
 
 Validation parses syntax and enforces command ordering. It does not start a shell, load a theme, run
-`Require` checks, or write output files. Use `betamax run` for a full execution check.
+[`Require`](../reference/tape-reference/#require-program) checks, or write output files. Use
+`betamax run` for a full execution check.
 
 ## List Themes
 
@@ -66,8 +68,9 @@ betamax themes --json
 betamax themes --markdown
 ```
 
-Use the exact theme name with `Set Theme "..."`. See [Themes And Styling](../authoring/themes/) for
-lookup behavior, layout settings, and frame decoration.
+Use the exact theme name with [`Set Theme "..."`](../reference/tape-reference/#settings). See
+[Themes And Styling](../authoring/themes/) for lookup behavior, layout settings, and frame
+decoration.
 
 ## Repository Examples
 

--- a/site/src/content/docs/reference/roadmap.mdx
+++ b/site/src/content/docs/reference/roadmap.mdx
@@ -11,7 +11,8 @@ follow-up work is about fidelity, API shape, and long-term renderer direction.
 1. Improve renderer fidelity around wide glyphs, combining marks, emoji, and fallback fonts.
    The current renderer is good enough for ordinary CLI output, but terminal UI tests will become
    more valuable as glyph edge cases get closer to real terminal behavior.
-1. Feed live terminal mode state into `libghostty-vt::key::Encoder`.
+1. Feed live terminal mode state into
+   [`libghostty-vt::key::Encoder`](../../reference/vhs-differences/).
    Key encoding works for common keys today, but richer mode-aware encoding would reduce fallback
    logic for applications that switch keypad or cursor modes.
 1. Decide whether the library API should expose structured artifacts without writing files.
@@ -22,8 +23,9 @@ follow-up work is about fidelity, API shape, and long-term renderer direction.
    and output writing explicit without making normal CLI code harder to read.
 1. Add targeted benchmarks after renderer and state formats settle.
    Performance tests are useful once the format and renderer behavior stop moving quickly.
-1. Keep MP4/WebM on optional `ffmpeg` unless native encoding becomes worth the packaging cost.
+1. Keep MP4/WebM on optional [ffmpeg](../../authoring/outputs/#video-encoding) unless native
+   encoding becomes worth the packaging cost.
    Native video encoding would remove a tool dependency but add platform and codec complexity.
-1. Track upstream libghostty APIs for renderer frame capture.
+1. Track upstream [libghostty](../../reference/vhs-differences/) APIs for renderer frame capture.
    If Ghostty exposes an off-screen renderer path, Betamax should prefer that over maintaining a
    parallel Rust rasterizer long term.

--- a/site/src/content/docs/reference/tape-reference.mdx
+++ b/site/src/content/docs/reference/tape-reference.mdx
@@ -30,8 +30,8 @@ waits, sleeps, screenshots, state checkpoints, `Hide`, `Show`, `Copy`, and `Past
 | `Output <path>.gif`     | Write an animated GIF                         | Encoded in process                          |
 | `Output <path>.png`     | Write a final-frame PNG                       | Encoded in process                          |
 | `Output <path>.json`    | Write final terminal state                    | See [State JSON](../../testing/state-json/) |
-| `Output <path>.mp4`     | Write MP4 video                               | Requires `ffmpeg` on `PATH`                 |
-| `Output <path>.webm`    | Write WebM video                              | Requires `ffmpeg` on `PATH`                 |
+| `Output <path>.mp4`     | Write MP4 video                               | Requires [ffmpeg][video-encoding] on `PATH` |
+| `Output <path>.webm`    | Write WebM video                              | Requires [ffmpeg][video-encoding] on `PATH` |
 | `Output <dir>`          | Write numbered PNG frames into a directory    | Extensionless path only                     |
 | `Screenshot <path>.png` | Write a checkpoint screenshot at this command | Only `.png` is supported                    |
 | `State <path>.json`     | Write checkpoint terminal state               | Only `.json` is supported                   |
@@ -198,3 +198,5 @@ Betamax currently exposes these CLI commands:
 
 `publish`, `record`, and `serve` remain explicit not-implemented commands so users migrating from
 VHS get a clear error message.
+
+[video-encoding]: ../../authoring/outputs/#video-encoding

--- a/site/src/content/docs/reference/vhs-differences.mdx
+++ b/site/src/content/docs/reference/vhs-differences.mdx
@@ -3,22 +3,22 @@ title: Differences From VHS
 description: What Betamax keeps, changes, and intentionally omits.
 ---
 
-Betamax follows the useful parts of the VHS authoring model: tape files, typed input, waits,
-themes, frame styling, GIF output, screenshots, and simple examples. The differences below focus on
-actual user-visible behavior, not implementation details that produce the same result.
+Betamax follows the useful parts of the VHS authoring model: [tape files][tape-files], typed input,
+waits, themes, frame styling, GIF output, screenshots, and simple examples. The differences below
+focus on actual user-visible behavior, not implementation details that produce the same result.
 
 ## Summary
 
-| Area            | VHS                          | Betamax                                                  |
-| --------------- | ---------------------------- | -------------------------------------------------------- |
-| Terminal stack  | Browser terminal stack       | PTY plus `libghostty-vt`, rendered in process            |
-| GIF and PNG     | Supported                    | Supported in process                                     |
-| MP4 and WebM    | Supported                    | Supported through `ffmpeg`                               |
-| State snapshots | Not a primary feature        | JSON viewport, scrollback, cursor, and styles            |
-| `Source`        | Executes included tapes      | Parsed, then rejected with a clear not-implemented error |
-| `record`        | Records interactive sessions | Intentionally not implemented                            |
-| `serve`         | Starts a server workflow     | Intentionally not implemented                            |
-| `publish`       | Upload/share workflow        | Intentionally not implemented                            |
+| Area            | VHS                          | Betamax                                                     |
+| --------------- | ---------------------------- | ----------------------------------------------------------- |
+| Terminal stack  | Browser terminal stack       | PTY plus [`libghostty-vt`][libghostty], rendered in process |
+| GIF and PNG     | Supported                    | Supported in process                                        |
+| MP4 and WebM    | Supported                    | Supported through [ffmpeg][video-encoding]                  |
+| State snapshots | Not a primary feature        | JSON viewport, scrollback, cursor, and styles               |
+| `Source`        | Executes included tapes      | Parsed, then rejected with a clear not-implemented error    |
+| `record`        | Records interactive sessions | Intentionally not implemented                               |
+| `serve`         | Starts a server workflow     | Intentionally not implemented                               |
+| `publish`       | Upload/share workflow        | Intentionally not implemented                               |
 
 ## Same Authoring Ideas
 
@@ -54,8 +54,12 @@ See [Terminal Testing](../../testing/terminal-testing/) and
 
 ## Video Tradeoff
 
-MP4 and WebM use `ffmpeg`. That keeps container encoding reliable and avoids adding native video
-encoder complexity to the first cut. GIF, PNG, screenshots, terminal parsing, rasterization, and
-state JSON are still handled in process.
+MP4 and WebM use [ffmpeg][video-encoding]. That keeps container encoding reliable and avoids adding
+native video encoder complexity to the first cut. GIF, PNG, screenshots, terminal parsing,
+rasterization, and state JSON are still handled in process.
 
 Use [Outputs](../../authoring/outputs/) for installation notes and output selection guidance.
+
+[libghostty]: #summary
+[tape-files]: ../../authoring/tape-files/
+[video-encoding]: ../../authoring/outputs/#video-encoding

--- a/site/src/content/docs/testing/state-json.mdx
+++ b/site/src/content/docs/testing/state-json.mdx
@@ -37,7 +37,8 @@ Write final state with `Output <path>.json` or checkpoint state with `State <pat
 Important fields:
 
 - `size` is `[columns, rows]` for the PTY grid.
-- `total_rows` is the total rows reported by `libghostty-vt`, including scrollback and viewport.
+- `total_rows` is the total rows reported by
+  [`libghostty-vt`](../../reference/vhs-differences/), including scrollback and viewport.
 - `scrollback_rows` is the number of rows currently available above the viewport.
 - `title` and `working_directory` are included only when non-empty.
 - `cursor` is zero-based within the visible viewport.


### PR DESCRIPTION
## Summary

- add a dedicated Starlight overview page and point the sidebar Overview link at it instead of the splash page
- link the splash page, overview, authoring docs, reference docs, and examples through the relevant concept and command pages
- add internal links for tape commands, output formats, Ghostty/VHS concepts, state JSON, terminal testing, and video encoding, plus external links for upstream tools that do not have Betamax-owned pages

## Validation

- pnpm exec markdownlint-cli2 site/src/content/docs/**/*.mdx
- pnpm docs:check
- pnpm docs:build