### PR TITLE
Clarify source checkout run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the CLI from crates.io:
 cargo install betamax --locked
 ```
 
-Until then, run from the workspace:
+For local development or source checkouts, run from the workspace:
 
 ```sh
 cargo run -- run examples/basic.tape


### PR DESCRIPTION
## Summary
- replace stale "Until then" wording after the crates.io install command with source-checkout wording
- keep the workspace `cargo run -- run examples/basic.tape` example unchanged

## Validation
- `git diff --check` passed
- `just lint-md` not run: `just` is not installed in this environment
- `markdownlint-cli2` not run: not installed in this environment