### PR TITLE
Clarify contributor communication channels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,15 @@ title: "Bug: "
 labels:
   - bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a reproducible Betamax bug.
+
+        If this is a question, early idea, or a note about what you built with Betamax,
+        please use [Discussions](https://github.com/joshka/betamax/discussions) instead.
+        The [Show and tell](https://github.com/joshka/betamax/discussions/categories/show-and-tell)
+        category is especially welcome for examples, screenshots, rendered tapes, and project links.
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Documentation
     url: https://www.joshka.net/betamax/
     about: Check the documentation site for tape syntax and command behavior.
+  - name: Show what you built
+    url: https://github.com/joshka/betamax/discussions/new?category=show-and-tell&welcome_text=true
+    about: Share how Betamax helps your project in Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,6 +4,15 @@ title: "Feature: "
 labels:
   - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a focused Betamax improvement.
+
+        If this is a question, early idea, or a note about what you built with Betamax,
+        please use [Discussions](https://github.com/joshka/betamax/discussions) instead.
+        The [Show and tell](https://github.com/joshka/betamax/discussions/categories/show-and-tell)
+        category is especially welcome for examples, screenshots, rendered tapes, and project links.
   - type: textarea
     id: problem
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,7 @@ just check
 ## Notes
 
 Mention docs, examples, release notes, or follow-up work when relevant.
+
+If Betamax helped your project, consider sharing a short note or screenshot in
+[Discussions](https://github.com/joshka/betamax/discussions/new?category=show-and-tell&welcome_text=true).
+Open source work can be quiet, and real examples help maintainers understand what is useful.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,7 @@ titles such as `Document contributor workflow` or `Fix state JSON style spans`.
 
 Pull requests should explain the user-visible behavior, mention relevant docs or examples, and
 include validation commands run, especially `just check` or why a narrower check was sufficient.
+
+Route questions, early ideas, and examples of Betamax in real projects to GitHub Discussions
+instead of issues. Use the `Show and tell` category for screenshots, rendered tapes, repo links, and
+short notes about how Betamax helps another project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,12 @@ Pull requests should explain user-visible behavior, mention relevant docs or exa
 validation commands run. If `just check` was not run, note which narrower check was sufficient and
 why.
 
+Questions, early ideas, and examples of Betamax in real projects should go to
+[Discussions](https://github.com/joshka/betamax/discussions) instead of issues. The
+[Show and tell](https://github.com/joshka/betamax/discussions/categories/show-and-tell) category is
+for screenshots, rendered tapes, repo links, and short notes about how Betamax helps another
+project.
+
 ## Release Notes
 
 User-visible changes should update [CHANGELOG.md](CHANGELOG.md). Keep entries short and focused on

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ terminal state, and fail when expected terminal output does not appear before a 
 See [Terminal Testing][terminal-testing] and [State JSON][state-json] for the test
 workflow and state snapshot format.
 
+## Community
+
+Questions, early ideas, and examples of Betamax in real projects belong in
+[Discussions][discussions]. If Betamax helped you make a demo, test a terminal UI, document a CLI,
+or replace part of an existing workflow, please share a screenshot, rendered tape, repo link, or
+short note in [Show and tell][show-and-tell].
+
 ## Documentation
 
 - [Documentation Site][docs-site]
@@ -176,8 +183,10 @@ just docs-site-dev
 ```
 
 [basic-gif]: https://github.com/joshka/betamax/releases/download/readme-assets/basic.gif
+[discussions]: https://github.com/joshka/betamax/discussions
 [docs-site]: https://www.joshka.net/betamax/
 [hide-show-gif]: https://github.com/joshka/betamax/releases/download/readme-assets/hide-show.gif
+[show-and-tell]: https://github.com/joshka/betamax/discussions/categories/show-and-tell
 [state-json]: https://www.joshka.net/betamax/testing/state-json/
 [tape-reference]: https://www.joshka.net/betamax/reference/tape-reference/
 [terminal-testing]: https://www.joshka.net/betamax/testing/terminal-testing/


### PR DESCRIPTION
## Summary

- Route questions, early ideas, and showcase-style posts to GitHub Discussions instead of issues.
- Add Show and tell links from the issue chooser, issue forms, PR template, README, contributing guide, and agent guidance.
- Keep reproducible bugs and focused feature requests on the issue path.

## Validation

```sh
npx --yes markdownlint-cli2 README.md CONTRIBUTING.md AGENTS.md .github/pull_request_template.md
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml
```