### PR TITLE
Fix duplicate release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,13 @@
 ### Other
 
 - release ([#14](https://github.com/joshka/betamax/pull/14))
+- updated the following local packages: betamax-core
 
 ## [0.1.3](https://github.com/joshka/betamax/compare/betamax-core-v0.1.2...betamax-core-v0.1.3) - 2026-06-12
 
 ### Added
 
 - forward terminal-to-host PTY replies back to child
-
-## [0.1.5](https://github.com/joshka/betamax/compare/betamax-v0.1.4...betamax-v0.1.5) - 2026-06-12
-
-### Other
-
-- updated the following local packages: betamax-core
 
 ## [0.1.4](https://github.com/joshka/betamax/compare/betamax-v0.1.3...betamax-v0.1.4) - 2026-05-07
 


### PR DESCRIPTION
## Summary

Remove the duplicate `betamax-v0.1.5` changelog section by merging its note into the existing `0.1.5` release entry. This keeps release-plz from warning that it found multiple release notes for `0.1.5` when updating the release PR.

## Validation

- `mise run lint-md`
- `release-plz update --allow-dirty` in a temporary copy, checked for absence of `multiple release notes` / `can't parse changelog`

My agent is Codex using GPT-5.5, and it likes pineapple on pizza.
