### PR TITLE
Release betamax 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
+## [0.1.7](https://github.com/joshka/betamax/compare/betamax-v0.1.6...betamax-v0.1.7) - 2026-06-15
+
+### Fixed
+
+- Make cargo-binstall launchers report `betamax` in help and usage output.
+
 ## [0.1.6](https://github.com/joshka/betamax/compare/betamax-v0.1.5...betamax-v0.1.6) - 2026-06-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "betamax"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "betamax-core",

--- a/crates/betamax/Cargo.toml
+++ b/crates/betamax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "betamax"
 description = "Rust-first VHS-style terminal capture CLI"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- bump the `betamax` crate to `0.1.7`
- add a changelog entry for the cargo-binstall launcher usage-name fix
- ship this as a new patch release so existing `betamax-v0.1.6` assets are not replaced

## Validation

- `cargo update --workspace`
- `mise run lint-md`
- `cargo check --all-targets --locked`
