### PR TITLE
Add quick-start Betamax tape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
- "tracing",
 ]
 
 [[package]]
@@ -247,6 +246,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ documentation = "https://www.joshka.net/betamax/"
 [workspace.dependencies]
 anyhow = "1.0.100"
 betamax-core = { path = "crates/betamax-core", version = "0.1.3" }
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive", "wrap_help"] }
 clap-stdin = "0.8"
 cosmic-text = "0.19"
 gif = "0.14"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The checked-in examples are small smoke-test tapes that demonstrate core behavio
 | `examples/themes.tape`           | copied Ghostty themes and palette mapping      | `themes.gif`        |
 | `examples/screenshot.tape`       | screenshots and terminal state JSON            | `screenshot.png`    |
 | `examples/video.tape`            | GIF, MP4, and WebM from one capture            | `video.*`           |
+| `examples/quick-start.tape`      | installing, help, `new`, and nested `run`      | `quick-start.gif`   |
 
 ### Basic
 

--- a/crates/betamax-core/Cargo.toml
+++ b/crates/betamax-core/Cargo.toml
@@ -31,7 +31,6 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shell-words.workspace = true
-tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/betamax-core/resources/ghostty/themes/Betamax Brownout
+++ b/crates/betamax-core/resources/ghostty/themes/Betamax Brownout
@@ -1,0 +1,33 @@
+# Betamax Brownout
+# Ghostty theme inspired by joshka.net/betamax.
+# Warm, intentionally "wrong" ANSI colors: espresso, oxide red, amber orange,
+# brass, aged tape-label cream.
+
+background = #0d0b08
+foreground = #e8cda3
+
+cursor-color = #f28a24
+cursor-text = #120c08
+
+selection-background = #3a2618
+selection-foreground = #ffe0a8
+
+# ANSI 0-7
+palette = 0=#15100b
+palette = 1=#b83a1b
+palette = 2=#a65a1a
+palette = 3=#d47a13
+palette = 4=#7a3b22
+palette = 5=#c45a24
+palette = 6=#c99a5a
+palette = 7=#d8b98a
+
+# Bright ANSI 8-15
+palette = 8=#3a2a1d
+palette = 9=#e35120
+palette = 10=#c96e1d
+palette = 11=#f09a20
+palette = 12=#9a4b29
+palette = 13=#e06b2e
+palette = 14=#e8b866
+palette = 15=#ffe3b3

--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -62,7 +62,7 @@ use crate::media::{
     write_gif, write_json, write_mp4, write_png, write_png_sequence, write_webm, Frame,
 };
 use crate::output::{classify_outputs, Outputs};
-use crate::tape::{Command, Tape};
+use crate::tape::{Command, Key, KeyCode, Tape, Value, WaitPattern, WaitTarget};
 
 /// Terminal session used by the runner's capture path.
 ///
@@ -132,6 +132,13 @@ const FINAL_COMMAND_IDLE: Duration = Duration::from_millis(100);
 /// Inline checkpoints should reflect output produced by the preceding command, but they should not
 /// wait as long as shell startup because they often appear in the middle of visible recordings.
 const CHECKPOINT_IDLE: Duration = Duration::from_millis(50);
+
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_BOLD: &str = "\x1b[1m";
+const ANSI_DIM: &str = "\x1b[2m";
+const ANSI_CYAN: &str = "\x1b[36m";
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_YELLOW: &str = "\x1b[33m";
 
 /// Runs parsed tapes.
 ///
@@ -335,7 +342,9 @@ where
         let mut clipboard = String::new();
         session.drain_into(&mut terminal, SHELL_STARTUP_IDLE)?;
 
-        for command in &tape.commands {
+        let command_count = tape.commands.len();
+        for (index, command) in tape.commands.iter().enumerate() {
+            self.progress_command(index + 1, command_count, command);
             self.run_capture_command(
                 command,
                 &settings,
@@ -366,22 +375,49 @@ where
         let final_state = terminal.terminal_state()?;
 
         for path in outputs.pngs {
+            self.progress(
+                ANSI_YELLOW,
+                format_args!("generating png {}", path.display()),
+            );
             write_png(&path, &frame)?;
+            self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.states {
+            self.progress(
+                ANSI_YELLOW,
+                format_args!("writing state {}", path.display()),
+            );
             write_json(&path, &final_state)?;
+            self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.gifs {
+            self.progress(
+                ANSI_YELLOW,
+                format_args!("combining frames into gif {}", path.display()),
+            );
             write_gif(&path, &capture.frames)?;
+            self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.frame_dirs {
+            self.progress(
+                ANSI_YELLOW,
+                format_args!("writing frame sequence {}", path.display()),
+            );
             write_png_sequence(&path, &capture.frames)?;
+            self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.mp4s {
+            self.progress(ANSI_YELLOW, format_args!("encoding mp4 {}", path.display()));
             write_mp4(&path, &capture.frames, settings.output_framerate())?;
+            self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.webms {
+            self.progress(
+                ANSI_YELLOW,
+                format_args!("encoding webm {}", path.display()),
+            );
             write_webm(&path, &capture.frames, settings.output_framerate())?;
+            self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
 
         Ok(RunArtifacts {
@@ -497,7 +533,9 @@ where
         let mut session = PtySession::spawn(&settings)?;
         let mut clipboard = String::new();
         session.drain_output(SHELL_STARTUP_IDLE)?;
-        for command in &tape.commands {
+        let command_count = tape.commands.len();
+        for (index, command) in tape.commands.iter().enumerate() {
+            self.progress_command(index + 1, command_count, command);
             match command {
                 Command::Sleep(duration) => thread::sleep(*duration),
                 Command::Type { text, delay } => session.type_text(text, *delay)?,
@@ -545,15 +583,177 @@ where
             }
         }
 
-        if !self.options.quiet {
-            tracing::info!("tape executed without capture outputs");
-        }
+        self.progress(
+            ANSI_GREEN,
+            format_args!("tape executed without capture outputs"),
+        );
 
         Ok(RunArtifacts {
             final_state: None,
             output_paths: Vec::new(),
         })
     }
+
+    fn progress_command(&self, index: usize, count: usize, command: &Command) {
+        let (style, label) = match command {
+            Command::Output(_)
+            | Command::Require(_)
+            | Command::Set { .. }
+            | Command::Env { .. } => (ANSI_DIM, "setup"),
+            Command::Sleep(_) | Command::Wait { .. } => (ANSI_YELLOW, "wait"),
+            Command::Screenshot(_) | Command::State(_) => (ANSI_YELLOW, "capture"),
+            Command::Hide | Command::Show => (ANSI_DIM, "display"),
+            _ => (ANSI_CYAN, "run"),
+        };
+        self.progress(
+            style,
+            format_args!(
+                "{ANSI_BOLD}{label}{ANSI_RESET}{style} {index}/{count}: {}",
+                describe_command(command)
+            ),
+        );
+    }
+
+    fn progress(&self, style: &str, args: std::fmt::Arguments<'_>) {
+        if !self.options.quiet {
+            println!("{style}{args}{ANSI_RESET}");
+        }
+    }
+}
+
+fn describe_command(command: &Command) -> String {
+    match command {
+        Command::Output(path) => format!("Output {}", path.display()),
+        Command::Require(program) => format!("Require {program}"),
+        Command::Set { key, value } => format!("Set {key} {}", describe_value(value)),
+        Command::Sleep(duration) => format!("Sleep {}", describe_duration(*duration)),
+        Command::Type { text, delay } => match delay {
+            Some(delay) => format!(
+                "Type@{} \"{}\"",
+                describe_duration(*delay),
+                describe_text(text)
+            ),
+            None => format!("Type \"{}\"", describe_text(text)),
+        },
+        Command::Wait {
+            target,
+            pattern,
+            timeout,
+        } => {
+            let target = match target {
+                WaitTarget::Line => "Line",
+                WaitTarget::Screen => "Screen",
+            };
+            let pattern = pattern
+                .as_ref()
+                .map(describe_wait_pattern)
+                .unwrap_or_else(|| "default prompt".to_string());
+            match timeout {
+                Some(timeout) => {
+                    format!("Wait+{target}@{} {pattern}", describe_duration(*timeout))
+                }
+                None => format!("Wait+{target} {pattern}"),
+            }
+        }
+        Command::Key { key, delay, count } => {
+            let key = describe_key(key);
+            let suffix = delay
+                .map(|delay| format!("@{}", describe_duration(delay)))
+                .unwrap_or_default();
+            if *count == 1 {
+                format!("{key}{suffix}")
+            } else {
+                format!("{key}{suffix} {count}")
+            }
+        }
+        Command::Hide => "Hide".to_string(),
+        Command::Show => "Show".to_string(),
+        Command::Env { key, .. } => format!("Env {key} <value>"),
+        Command::Copy(text) => format!("Copy \"{}\"", describe_text(text)),
+        Command::Paste => "Paste".to_string(),
+        Command::Source(path) => format!("Source {}", path.display()),
+        Command::Screenshot(path) => format!("Screenshot {}", path.display()),
+        Command::State(path) => format!("State {}", path.display()),
+    }
+}
+
+fn describe_value(value: &Value) -> String {
+    match value {
+        Value::String(value) => format!("\"{}\"", describe_text(value)),
+        Value::Number(value) => value.to_string(),
+        Value::Duration(value) => describe_duration(*value),
+        Value::Bool(value) => value.to_string(),
+    }
+}
+
+fn describe_wait_pattern(pattern: &WaitPattern) -> String {
+    match pattern {
+        WaitPattern::Contains(text) => format!("\"{}\"", describe_text(text)),
+        WaitPattern::Regex(regex) => format!("/{}/", describe_text(regex)),
+    }
+}
+
+fn describe_key(key: &Key) -> String {
+    let Key::Press { key, modifiers } = key;
+    let mut parts = Vec::new();
+    if modifiers.ctrl {
+        parts.push("Ctrl".to_string());
+    }
+    if modifiers.alt {
+        parts.push("Alt".to_string());
+    }
+    if modifiers.shift {
+        parts.push("Shift".to_string());
+    }
+    parts.push(match key {
+        KeyCode::Backspace => "Backspace".to_string(),
+        KeyCode::Delete => "Delete".to_string(),
+        KeyCode::Down => "Down".to_string(),
+        KeyCode::End => "End".to_string(),
+        KeyCode::Enter => "Enter".to_string(),
+        KeyCode::Escape => "Escape".to_string(),
+        KeyCode::Function(number) => format!("F{number}"),
+        KeyCode::Home => "Home".to_string(),
+        KeyCode::Insert => "Insert".to_string(),
+        KeyCode::Left => "Left".to_string(),
+        KeyCode::PageDown => "PageDown".to_string(),
+        KeyCode::PageUp => "PageUp".to_string(),
+        KeyCode::Right => "Right".to_string(),
+        KeyCode::Space => "Space".to_string(),
+        KeyCode::Tab => "Tab".to_string(),
+        KeyCode::Up => "Up".to_string(),
+        KeyCode::Char(ch) => ch.to_string(),
+    });
+    parts.join("+")
+}
+
+fn describe_duration(duration: Duration) -> String {
+    let milliseconds = duration.as_millis();
+    if milliseconds.is_multiple_of(1000) {
+        format!("{}s", milliseconds / 1000)
+    } else {
+        format!("{milliseconds}ms")
+    }
+}
+
+fn describe_text(text: &str) -> String {
+    const MAX_CHARS: usize = 72;
+    let mut output = String::new();
+    let mut chars = text.chars();
+    for ch in chars.by_ref().take(MAX_CHARS) {
+        match ch {
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            ch => output.push(ch),
+        }
+    }
+    if chars.next().is_some() {
+        output.push('…');
+    }
+    output
 }
 
 #[cfg(test)]

--- a/crates/betamax-core/src/runner/options.rs
+++ b/crates/betamax-core/src/runner/options.rs
@@ -11,9 +11,8 @@ pub struct RunOptions {
     /// This option exists to keep the public API compatible with the VHS-shaped CLI surface, but
     /// publishing is intentionally not implemented in the current Ghostty-first runner.
     pub publish: bool,
-    /// Suppress informational logs from successful no-capture execution.
+    /// Suppress informational logs from successful execution.
     ///
-    /// Errors are still returned normally. Capture runs currently do not emit routine progress
-    /// logs.
+    /// Errors are still returned normally.
     pub quiet: bool,
 }

--- a/crates/betamax/src/commands/run.rs
+++ b/crates/betamax/src/commands/run.rs
@@ -10,6 +10,9 @@ use betamax_core::tape::Tape;
 use clap_stdin::FileOrStdin;
 use miette::{IntoDiagnostic, Result};
 
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_BLUE: &str = "\x1b[34m";
+
 #[derive(Debug, clap::Parser)]
 pub struct Run {
     /// File to read input from, or `-` for stdin
@@ -39,6 +42,9 @@ impl Run {
     /// Returns an error if the input cannot be read, the tape cannot be parsed, runner execution
     /// fails, or a requested output cannot be written.
     pub fn run(&self) -> Result<()> {
+        if !self.quiet {
+            println!("{ANSI_BLUE}running {}{ANSI_RESET}", self.input.filename());
+        }
         let source = self.input.clone().contents().into_diagnostic()?;
         let mut tape = Tape::parse(&source)?;
         if let Some(output) = &self.output {
@@ -49,6 +55,7 @@ impl Run {
             publish: self.publish,
             quiet: self.quiet,
         };
-        Ok(Runner::new(options).run(&tape)?)
+        Runner::new(options).run(&tape)?;
+        Ok(())
     }
 }

--- a/examples/quick-start.tape
+++ b/examples/quick-start.tape
@@ -1,0 +1,89 @@
+# Render the quick-start demo and a still frame for theme/layout inspection.
+Output examples/output/quick-start.gif
+
+Require cargo
+Require cargo-binstall
+
+# Use the local Brownout Ghostty theme and a warm outer margin.
+Set Shell "bash"
+Set Theme "Betamax Brownout"
+Set Width 1000
+Set Height 820
+Set Margin 16
+Set MarginFill "#20140d"
+Set WindowBar Colorful
+Set WindowBarSize 34
+Set BorderRadius 8
+Set Framerate 12
+Set TypingSpeed 8ms
+Set CursorBlink false
+
+# Match the prompt to the Brownout ANSI palette instead of Betamax's default purple prompt.
+Env PS1 '\[\e[33m\]> \[\e[0m\]'
+
+# Prepare a temporary work directory without showing setup commands in the recording.
+Hide
+Type "export PATH=\"$HOME/.cargo/bin:$PATH\""
+Enter
+Wait
+Type "workdir=$(mktemp -d)"
+Enter
+Wait
+Type "cd \"$workdir\""
+Enter
+Wait
+Type "clear"
+Enter
+Wait
+Show
+Screenshot examples/output/quick-start-start.png
+
+# Install or confirm the released CLI binary.
+Type "cargo binstall -y betamax"
+Sleep 500ms
+Enter
+Wait+Screen@2m "Done"
+Sleep 2s
+
+# Show the installed command surface.
+Type "betamax --help"
+Sleep 500ms
+Enter
+Wait+Screen "--version"
+Sleep 2s
+
+# Create a starter tape.
+Type "betamax new new.tape"
+Sleep 500ms
+Enter
+Wait
+Sleep 2s
+
+# Show the executable body of the generated tape without the reference comments.
+Type "sed -n '/^Output/,$p' new.tape"
+Sleep 500ms
+Enter
+Wait+Screen "Output new.gif"
+Sleep 2s
+
+# Run the generated tape and show Betamax's own progress output.
+Type "betamax run new.tape"
+Sleep 500ms
+Enter
+Wait+Screen@2m "wrote new.gif"
+Sleep 2s
+
+# Verify the generated GIF.
+Type "ls -lh new.gif"
+Sleep 500ms
+Enter
+Wait+Screen "/-rw.*new\\.gif/"
+Sleep 4s
+
+# Remove temporary files after recording stops.
+Hide
+Type "rm -f new.gif new.tape"
+Enter
+Wait
+Type "cd / && rmdir \"$workdir\""
+Enter


### PR DESCRIPTION
## Summary

- add a bundled Betamax Brownout Ghostty theme
- add a quick-start tape that installs Betamax, shows help, creates a starter tape, runs it, and verifies the generated GIF
- add colored `betamax run` progress output for command execution and artifact generation
- enable Clap help wrapping so captured help output fits the demo width

## Validation

- `cargo check --quiet`
- `cargo run --quiet -- validate examples/*.tape`
- `mise run lint-md`
