### PR TITLE
Document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,19 @@ intentionally does not include `serve`, `record`, `source`, or `publish`.
 Betamax currently supports macOS and Linux. Windows is not supported because the upstream
 `libghostty-vt-sys` native build does not support Windows.
 
-Install the CLI from crates.io:
+Install the CLI with Homebrew from [joshka/homebrew-tap][homebrew-tap]:
+
+```sh
+brew install joshka/tap/betamax
+```
+
+If Homebrew requires trusted taps, trust the formula first:
+
+```sh
+brew trust --formula joshka/tap/betamax
+```
+
+Or install from crates.io with cargo-binstall:
 
 ```sh
 cargo binstall betamax
@@ -209,6 +221,7 @@ mise run docs-site-dev
 [docs-site]: https://www.joshka.net/betamax/
 [ffmpeg]: https://ffmpeg.org/
 [hide-show-gif]: https://github.com/joshka/betamax/releases/download/readme-assets/hide-show.gif
+[homebrew-tap]: https://github.com/joshka/homebrew-tap
 [mise]: https://mise.jdx.dev/
 [nix]: https://nixos.org/
 [show-and-tell]: https://github.com/joshka/betamax/discussions/categories/show-and-tell

--- a/crates/betamax/README.md
+++ b/crates/betamax/README.md
@@ -14,6 +14,20 @@ tests for terminal applications.
 Betamax currently supports macOS and Linux. Windows is not supported because the upstream
 `libghostty-vt-sys` native build does not support Windows.
 
+Install the CLI with Homebrew from [joshka/homebrew-tap][homebrew-tap]:
+
+```sh
+brew install joshka/tap/betamax
+```
+
+If Homebrew requires trusted taps, trust the formula first:
+
+```sh
+brew trust --formula joshka/tap/betamax
+```
+
+Or install from crates.io with cargo-binstall:
+
 ```sh
 cargo binstall betamax
 ```
@@ -197,6 +211,7 @@ See [Differences From VHS][vhs-differences] for the full comparison.
 [docs-site]: https://www.joshka.net/betamax/
 [ffmpeg]: https://ffmpeg.org/
 [hide-show-gif]: https://github.com/joshka/betamax/releases/download/readme-assets/hide-show.gif
+[homebrew-tap]: https://github.com/joshka/homebrew-tap
 [mise]: https://mise.jdx.dev/
 [nix]: https://nixos.org/
 [repo-readme]: https://github.com/joshka/betamax

--- a/docs/development.md
+++ b/docs/development.md
@@ -116,7 +116,19 @@ mise run install-local
 
 ## Installation Modes
 
-Published users should install Betamax with [cargo-binstall][cargo-binstall]:
+Users can install Betamax with Homebrew from [joshka/homebrew-tap][homebrew-tap]:
+
+```sh
+brew install joshka/tap/betamax
+```
+
+If Homebrew requires trusted taps, trust the formula first:
+
+```sh
+brew trust --formula joshka/tap/betamax
+```
+
+They can also install from crates.io with [cargo-binstall][cargo-binstall]:
 
 ```sh
 cargo binstall betamax
@@ -230,6 +242,7 @@ mise run upload-readme-assets
 [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
 [cargo-deny]: https://github.com/EmbarkStudios/cargo-deny
 [ffmpeg]: https://ffmpeg.org/
+[homebrew-tap]: https://github.com/joshka/homebrew-tap
 [mise]: https://mise.jdx.dev/
 [nix]: https://nixos.org/
 [pnpm]: https://pnpm.io/

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -8,7 +8,19 @@ Betamax currently supports macOS and Linux. Windows is not supported because the
 
 ## Install
 
-Install Rust and Cargo with [rustup][rustup], then install the release binary with
+Install the CLI with Homebrew from [joshka/homebrew-tap][homebrew-tap]:
+
+```sh
+brew install joshka/tap/betamax
+```
+
+If Homebrew requires trusted taps, trust the formula first:
+
+```sh
+brew trust --formula joshka/tap/betamax
+```
+
+Or install Rust and Cargo with [rustup][rustup], then install from crates.io with
 [cargo-binstall][cargo-binstall]:
 
 ```sh
@@ -118,6 +130,7 @@ local inspection. The [Examples](../examples/) page explains what each tape demo
 [Tape Reference](../reference/tape-reference/) documents every command and setting.
 
 [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
+[homebrew-tap]: https://github.com/joshka/homebrew-tap
 [mise]: https://mise.jdx.dev/
 [nix]: https://nixos.org/
 [pnpm]: https://pnpm.io/


### PR DESCRIPTION
## Summary
- Add Homebrew tap install commands to the root README and crate README.
- Add Homebrew as a published-user install mode in the development docs.
- Update the docs site quick start to show the Homebrew path before cargo-binstall.

## Checks
- mise run lint-md
- mise run docs-site-check
- mise run docs-site-build