### PR TITLE
Add homepage quick-start demo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+site/public/assets/betamax-hero-terminal.png filter=lfs diff=lfs merge=lfs -text
+site/public/assets/betamax-hero-quick-start.gif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The checked-in examples are small smoke-test tapes that demonstrate core behavio
 
 | Tape                             | Demonstrates                                   | Main Output         |
 | -------------------------------- | ---------------------------------------------- | ------------------- |
+| `examples/quick-start.tape`      | installing, help, `new`, and nested `run`      | `quick-start.gif`   |
 | `examples/basic.tape`            | typing, wait, theme, window bar, border radius | `basic.gif`         |
 | `examples/hide-show.tape`        | hidden setup and hidden trailing cleanup       | `hide-show.gif`     |
 | `examples/waits.tape`            | line, screen, regex, and default prompt waits  | `waits.gif`         |
@@ -128,7 +129,10 @@ The checked-in examples are small smoke-test tapes that demonstrate core behavio
 | `examples/themes.tape`           | copied Ghostty themes and palette mapping      | `themes.gif`        |
 | `examples/screenshot.tape`       | screenshots and terminal state JSON            | `screenshot.png`    |
 | `examples/video.tape`            | GIF, MP4, and WebM from one capture            | `video.*`           |
-| `examples/quick-start.tape`      | installing, help, `new`, and nested `run`      | `quick-start.gif`   |
+
+### Quick Start
+
+![Quick Start Betamax GIF][quick-start-gif]
 
 ### Basic
 
@@ -224,6 +228,7 @@ mise run docs-site-dev
 [homebrew-tap]: https://github.com/joshka/homebrew-tap
 [mise]: https://mise.jdx.dev/
 [nix]: https://nixos.org/
+[quick-start-gif]: https://github.com/joshka/betamax/releases/download/readme-assets/quick-start.gif
 [show-and-tell]: https://github.com/joshka/betamax/discussions/categories/show-and-tell
 [state-json]: https://www.joshka.net/betamax/testing/state-json/
 [tape-reference]: https://www.joshka.net/betamax/reference/tape-reference/

--- a/crates/betamax/README.md
+++ b/crates/betamax/README.md
@@ -124,6 +124,7 @@ The repository includes tapes that exercise the core behavior:
 
 | Tape                          | Demonstrates                                   |
 | ----------------------------- | ---------------------------------------------- |
+| `examples/quick-start.tape`   | installing, help, `new`, and nested `run`      |
 | `examples/basic.tape`         | typing, wait, theme, window bar, border radius |
 | `examples/hide-show.tape`     | hidden setup and hidden trailing cleanup       |
 | `examples/waits.tape`         | line, screen, regex, and default prompt waits  |
@@ -135,6 +136,10 @@ The repository includes tapes that exercise the core behavior:
 | `examples/layout.tape`        | padding, margin, fill, window bar, radius      |
 | `examples/themes.tape`        | copied Ghostty themes and palette mapping      |
 | `examples/video.tape`         | GIF, MP4, and WebM from one capture            |
+
+### Quick Start
+
+![Quick Start Betamax GIF][quick-start-gif]
 
 ### Basic
 
@@ -214,6 +219,7 @@ See [Differences From VHS][vhs-differences] for the full comparison.
 [homebrew-tap]: https://github.com/joshka/homebrew-tap
 [mise]: https://mise.jdx.dev/
 [nix]: https://nixos.org/
+[quick-start-gif]: https://github.com/joshka/betamax/releases/download/readme-assets/quick-start.gif
 [repo-readme]: https://github.com/joshka/betamax
 [state-json]: https://www.joshka.net/betamax/testing/state-json/
 [tape-reference]: https://www.joshka.net/betamax/reference/tape-reference/

--- a/crates/betamax/src/commands/mod.rs
+++ b/crates/betamax/src/commands/mod.rs
@@ -5,7 +5,7 @@
 //! top-level argument parsing.
 
 use clap::Parser;
-use miette::{miette, Result};
+use miette::Result;
 
 mod list_themes;
 mod new;
@@ -22,17 +22,8 @@ pub enum Command {
     /// Create a new tape file with example tape file contents and documentation
     New(New),
 
-    /// Publish your GIF and get a shareable URL
-    Publish,
-
-    /// Create a new tape file by recording your actions
-    Record,
-
     /// Run a tape file
     Run(Run),
-
-    /// Start the SSH server
-    Serve,
 
     /// List available themes
     Themes(ListThemes),
@@ -45,20 +36,13 @@ pub enum Command {
 impl Command {
     /// Dispatch a parsed subcommand.
     ///
-    /// VHS commands that require network services or interactive recording are retained as explicit
-    /// "not implemented" errors so users get a clear answer instead of an unknown-command failure.
-    ///
     /// # Errors
     ///
-    /// Returns an error if the selected command fails or if the selected VHS-compatible command is
-    /// intentionally not implemented by Betamax.
+    /// Returns an error if the selected command fails.
     pub fn run(&self) -> Result<()> {
         match self {
             Command::New(command) => command.run()?,
-            Command::Publish => return Err(miette!("publish is intentionally not implemented")),
-            Command::Record => return Err(miette!("record is intentionally not implemented")),
             Command::Run(command) => command.run()?,
-            Command::Serve => return Err(miette!("serve is intentionally not implemented")),
             Command::Themes(command) => command.run()?,
             Command::Validate(command) => command.run()?,
         }

--- a/scripts/upload-readme-assets.sh
+++ b/scripts/upload-readme-assets.sh
@@ -21,6 +21,7 @@ if ! gh release view "$tag" >/dev/null 2>&1; then
 fi
 
 gh release upload "$tag" \
+  target/betamax-examples/quick-start.gif \
   target/betamax-examples/basic.gif \
   target/betamax-examples/hide-show.gif \
   target/betamax-examples/themes.gif \

--- a/site/public/assets/betamax-hero-quick-start.gif
+++ b/site/public/assets/betamax-hero-quick-start.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:193e9800139994d9c2bef2d2611040b461de7bfc3fa72d7d9497ebd4233e8066
+size 4162357

--- a/site/public/assets/betamax-hero-terminal.png
+++ b/site/public/assets/betamax-hero-terminal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29072ac6ab17cd1fdab57a25941bfc312f3517f5f03e74dfc62a094302f2b2be
+size 1359758

--- a/site/quick-start.tape
+++ b/site/quick-start.tape
@@ -1,0 +1,79 @@
+# Homepage quick-start recording.
+#
+# This is separate from `examples/quick-start.tape` because the homepage places the rendered
+# terminal inside a TV frame. Keep this tape frameless: no Betamax margin, window bar, or border
+# radius. The TV image supplies the outer frame.
+Output site/public/assets/betamax-hero-quick-start.gif
+
+Require cargo
+Require cargo-binstall
+
+Set Shell "bash"
+Set Theme "Betamax Brownout"
+# The TV frame wants a 780x520 terminal viewport with 80px of overscan padding around it.
+Set Width 940
+Set Height 680
+Set Padding 80
+Set Framerate 12
+Set TypingSpeed 8ms
+Set CursorBlink false
+
+Env PS1 '\[\e[33m\]> \[\e[0m\]'
+
+Hide
+Type "export PATH=\"$(pwd)/target/debug:$HOME/.cargo/bin:$PATH\""
+Enter
+Wait
+Type "workdir=$(mktemp -d)"
+Enter
+Wait
+Type "cd \"$workdir\""
+Enter
+Wait
+Type "clear"
+Enter
+Wait
+Show
+
+Type "cargo binstall -y betamax"
+Sleep 500ms
+Enter
+Wait+Screen@2m "Done"
+Sleep 2s
+
+Type "betamax --help"
+Sleep 500ms
+Enter
+Wait+Screen "--version"
+Sleep 2s
+
+Type "betamax new new.tape"
+Sleep 500ms
+Enter
+Wait
+Sleep 2s
+
+Type "sed -n '/^Output/,$p' new.tape"
+Sleep 500ms
+Enter
+Wait+Screen "Output new.gif"
+Sleep 2s
+
+Type "betamax run new.tape"
+Sleep 500ms
+Enter
+Wait+Screen@2m "wrote new.gif"
+Sleep 2s
+
+Type "ls -lh new.gif"
+Sleep 500ms
+Enter
+Wait
+Sleep 4s
+
+Hide
+Type "rm -f new.gif new.tape"
+Enter
+Wait
+Type "cd / && rmdir \"$workdir\""
+Enter

--- a/site/src/content/docs/examples.mdx
+++ b/site/src/content/docs/examples.mdx
@@ -19,6 +19,7 @@ local inspection. README and site GIF previews are hosted as GitHub Release asse
 
 | Tape                                      | Demonstrates                                    | Useful docs                                                            |
 | ----------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| [`quick-start.tape`][quick-start-src]     | installing, help, `new`, and nested `run`       | [Quick Start](../quick-start/)                                         |
 | [`basic.tape`][basic-src]                 | typing, waits, theme, window bar, border radius | [Tape files](../authoring/tape-files/), [themes](../authoring/themes/) |
 | [`hide-show.tape`][hide-show-src]         | hidden setup and hidden trailing cleanup        | [Hidden work](../authoring/tape-files/#hidden-work)                    |
 | [`waits.tape`][waits-src]                 | line, screen, regex, and default prompt waits   | [Wait commands](../reference/tape-reference/#waitduration-regextext)   |
@@ -35,6 +36,13 @@ local inspection. README and site GIF previews are hosted as GitHub Release asse
 ## Preview GIFs
 
 These previews come from the example tapes above.
+
+### Quick Start
+
+![Quick Start Betamax GIF](https://github.com/joshka/betamax/releases/download/readme-assets/quick-start.gif)
+
+`quick-start.tape` shows the full first-run path: install check, help output, creating a starter
+tape, inspecting it, running it, and listing the generated GIF.
 
 ### Basic
 
@@ -83,6 +91,7 @@ Use `examples/waits.tape` when debugging timing. It shows the three wait targets
 [keys-src]: https://github.com/joshka/betamax/blob/main/examples/keys.tape
 [layout-src]: https://github.com/joshka/betamax/blob/main/examples/layout.tape
 [outputs-src]: https://github.com/joshka/betamax/blob/main/examples/outputs.tape
+[quick-start-src]: https://github.com/joshka/betamax/blob/main/examples/quick-start.tape
 [screenshot-src]: https://github.com/joshka/betamax/blob/main/examples/screenshot.tape
 [scrollback-src]: https://github.com/joshka/betamax/blob/main/examples/scrollback.tape
 [text-styles-src]: https://github.com/joshka/betamax/blob/main/examples/text-styles.tape

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -30,6 +30,21 @@ template: splash
   </a>
 </section>
 
+<a class="betamax-terminal-demo" href="./quick-start/" aria-label="View the Betamax quick start">
+  <img
+    class="betamax-terminal-frame"
+    src="/betamax/assets/betamax-hero-terminal.png"
+    alt=""
+    loading="eager"
+  />
+  <img
+    class="betamax-terminal-screen"
+    src="/betamax/assets/betamax-hero-quick-start.gif"
+    alt="Betamax quick start recording rendered inside a terminal capture"
+    loading="eager"
+  />
+</a>
+
 Betamax reads <a href="./authoring/tape-files/">tape files</a>, runs commands in a real PTY, feeds
 terminal output through <a href="./reference/vhs-differences/">libghostty-vt</a>, rasterizes frames
 in process with <a href="https://github.com/pop-os/cosmic-text">cosmic-text</a> and

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -343,6 +343,50 @@ main:has(.betamax-hero) {
   filter: drop-shadow(0 1.5rem 1.7rem rgba(0, 0, 0, 0.6));
 }
 
+.betamax-terminal-demo {
+  position: relative;
+  left: 50%;
+  display: block;
+  width: min(96vw, 82rem);
+  margin: clamp(0.5rem, 2vw, 1.5rem) 0 clamp(1.5rem, 4vw, 3rem);
+  border: 0;
+  background: transparent;
+  transform: translateX(-50%);
+  isolation: isolate;
+}
+
+.betamax-terminal-demo::before {
+  content: '';
+  position: absolute;
+  z-index: 0;
+  inset: 60% 6% 0;
+  background: radial-gradient(ellipse at 50% 50%, rgba(224, 109, 41, 0.2), transparent 68%);
+  filter: blur(1rem);
+  pointer-events: none;
+}
+
+.betamax-terminal-frame {
+  position: relative;
+  z-index: 3;
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(0 1.4rem 2.2rem rgba(0, 0, 0, 0.72));
+}
+
+.betamax-terminal-screen {
+  position: absolute;
+  z-index: 2;
+  top: 12.2%;
+  left: 18.2%;
+  width: 63.4%;
+  height: 60.2%;
+  object-fit: cover;
+  border-radius: 7% / 5%;
+  filter: brightness(0.94) contrast(1.04) saturate(1.06);
+  pointer-events: none;
+}
+
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -587,6 +631,11 @@ main:has(.betamax-hero) {
 
   .betamax-demo img {
     min-height: 12rem;
+  }
+
+  .betamax-terminal-demo {
+    width: min(112vw, 54rem);
+    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a frameless homepage quick-start tape and TV-frame hero demo
- track the generated homepage GIF and terminal frame with Git LFS
- remove unimplemented commands from the displayed CLI help surface

## Validation
- cargo fmt --check
- cargo check --workspace --all-targets
- target/debug/betamax validate examples/quick-start.tape site/quick-start.tape
- mise run lint-md
- mise run docs-site-check
- mise run clippy
- mise run test
- mise run docs-site-build