### PR TITLE
Fetch LFS assets for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          lfs: true
           persist-credentials: false
 
       - name: Install mise tools
@@ -50,6 +51,12 @@ jobs:
 
       - name: Build docs
         run: mise run docs-site-build
+
+      - name: Check generated media
+        run: |
+          set -euo pipefail
+          file site/dist/assets/betamax-hero-terminal.png | grep -F "PNG image data"
+          file site/dist/assets/betamax-hero-quick-start.gif | grep -F "GIF image data"
 
       - name: Upload Pages artifact
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
- enable Git LFS checkout in the docs Pages workflow
- verify the built homepage media are real PNG/GIF files before uploading the Pages artifact

## Diagnosis
The deployed hero image URLs were serving 132-byte Git LFS pointer files. The Pages workflow log showed `actions/checkout` running with `lfs: false`, so `site/dist/assets` received pointers instead of media bytes.

## Validation
- `mise run lint-md`
- `mise run docs-site-build`
- `file site/dist/assets/betamax-hero-terminal.png site/dist/assets/betamax-hero-quick-start.gif`
