### PR TITLE
Render VHS summary as explicit table

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,8 @@ jobs:
           set -euo pipefail
           file site/dist/assets/betamax-hero-terminal.png | grep -F "PNG image data"
           file site/dist/assets/betamax-hero-quick-start.gif | grep -F "GIF image data"
+          grep -F "<table>" site/dist/reference/vhs-differences/index.html
+          ! grep -F "<p>| Area" site/dist/reference/vhs-differences/index.html
 
       - name: Upload Pages artifact
         if: ${{ github.event_name != 'pull_request' }}

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -12,6 +12,7 @@ config:
       - a
       - Card
       - CardGrid
+      - code
       - div
       - footer
       - h1
@@ -25,5 +26,11 @@ config:
       - section
       - span
       - svg
+      - table
+      - tbody
+      - td
+      - th
+      - thead
+      - tr
   MD024:
     siblings_only: true

--- a/site/src/content/docs/reference/vhs-differences.mdx
+++ b/site/src/content/docs/reference/vhs-differences.mdx
@@ -9,16 +9,61 @@ focus on actual user-visible behavior, not implementation details that produce t
 
 ## Summary
 
-| Area            | VHS                          | Betamax                                                     |
-| --------------- | ---------------------------- | ----------------------------------------------------------- |
-| Terminal stack  | Browser terminal stack       | PTY plus [`libghostty-vt`][libghostty], rendered in process |
-| GIF and PNG     | Supported                    | Supported in process                                        |
-| MP4 and WebM    | Supported                    | Supported through [ffmpeg][video-encoding]                  |
-| State snapshots | Not a primary feature        | JSON viewport, scrollback, cursor, and styles               |
-| `Source`        | Executes included tapes      | Parsed, then rejected with a clear not-implemented error    |
-| `record`        | Records interactive sessions | Intentionally not implemented                               |
-| `serve`         | Starts a server workflow     | Intentionally not implemented                               |
-| `publish`       | Upload/share workflow        | Intentionally not implemented                               |
+<table>
+  <thead>
+    <tr>
+      <th>Area</th>
+      <th>VHS</th>
+      <th>Betamax</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Terminal stack</td>
+      <td>Browser terminal stack</td>
+      <td>
+        PTY plus <a href="#summary"><code>libghostty-vt</code></a>, rendered in process
+      </td>
+    </tr>
+    <tr>
+      <td>GIF and PNG</td>
+      <td>Supported</td>
+      <td>Supported in process</td>
+    </tr>
+    <tr>
+      <td>MP4 and WebM</td>
+      <td>Supported</td>
+      <td>
+        Supported through <a href="../../authoring/outputs/#video-encoding">ffmpeg</a>
+      </td>
+    </tr>
+    <tr>
+      <td>State snapshots</td>
+      <td>Not a primary feature</td>
+      <td>JSON viewport, scrollback, cursor, and styles</td>
+    </tr>
+    <tr>
+      <td><code>Source</code></td>
+      <td>Executes included tapes</td>
+      <td>Parsed, then rejected with a clear not-implemented error</td>
+    </tr>
+    <tr>
+      <td><code>record</code></td>
+      <td>Records interactive sessions</td>
+      <td>Intentionally not implemented</td>
+    </tr>
+    <tr>
+      <td><code>serve</code></td>
+      <td>Starts a server workflow</td>
+      <td>Intentionally not implemented</td>
+    </tr>
+    <tr>
+      <td><code>publish</code></td>
+      <td>Upload/share workflow</td>
+      <td>Intentionally not implemented</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Same Authoring Ideas
 
@@ -60,6 +105,5 @@ rasterization, and state JSON are still handled in process.
 
 Use [Outputs](../../authoring/outputs/) for installation notes and output selection guidance.
 
-[libghostty]: #summary
 [tape-files]: ../../authoring/tape-files/
 [video-encoding]: ../../authoring/outputs/#video-encoding


### PR DESCRIPTION
## Summary
- render the VHS comparison summary with explicit MDX table markup
- allow table/code tags in markdownlint's MDX HTML allowlist
- check the built Pages artifact for a real table and no literal pipe-table paragraph

## Diagnosis
CI uses the current lockfile dependencies (`@astrojs/starlight` 0.39.3 / Astro 6.4.4). With that stack, the GFM table in `vhs-differences.mdx` was emitted as paragraph text in the Pages artifact. My local dev server initially looked fine because local `node_modules` was stale at older docs dependencies.

## Validation
- `pnpm install --frozen-lockfile`
- `mise run lint-md`
- `mise run docs-site-check`
- `mise run docs-site-build`
- `grep -F '<table>' site/dist/reference/vhs-differences/index.html`
- `! grep -F '<p>| Area' site/dist/reference/vhs-differences/index.html`
