### PR TITLE
Restyle docs internals

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,578 @@
+---
+version: alpha
+name: Betamax Analog Documentation
+description: >-
+  A dark, warm, 80s analog technical-manual design system for the Betamax documentation site. It
+  carries the homepage's VCR/Betamax identity into docs without using full hardware skeuomorphism.
+colors:
+  background: "#060403"
+  background-noise-base: "#0a0705"
+  margin-dark: "#030201"
+  sidebar: "#0d0906"
+  sidebar-raised: "#130d08"
+  surface: "#120d09"
+  surface-raised: "#1a110b"
+  surface-inset: "#080604"
+  surface-code: "#0b0806"
+  border-subtle: "#2a1a10"
+  border: "#4a2c18"
+  border-strong: "#70401f"
+  text: "#ead4b3"
+  text-strong: "#f4dfbd"
+  text-muted: "#b99066"
+  text-dim: "#7f6044"
+  link: "#f0782c"
+  link-hover: "#ff9a4a"
+  accent: "#d85b2a"
+  accent-dark: "#7f2118"
+  accent-orange: "#bd471d"
+  accent-amber: "#d48614"
+  stripe-cream: "#e6c997"
+  stripe-amber: "#d48614"
+  stripe-orange: "#bd471d"
+  stripe-red: "#7f2118"
+  success: "#9fbd73"
+  warning: "#d48614"
+  danger: "#c74227"
+typography:
+  display-xl:
+    fontFamily:
+      "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    fontSize: 56px
+    fontWeight: 800
+    lineHeight: 1.0
+    letterSpacing: 0
+  display-lg:
+    fontFamily:
+      "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    fontSize: 44px
+    fontWeight: 800
+    lineHeight: 1.05
+    letterSpacing: 0
+  heading-md:
+    fontFamily:
+      "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    fontSize: 26px
+    fontWeight: 700
+    lineHeight: 1.18
+    letterSpacing: 0
+  heading-sm:
+    fontFamily:
+      "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    fontSize: 20px
+    fontWeight: 700
+    lineHeight: 1.25
+  body-md:
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace"
+    fontSize: 15px
+    fontWeight: 400
+    lineHeight: 1.68
+  body-sm:
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.6
+  code-md:
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.55
+  label-caps:
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace"
+    fontSize: 12px
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: 0.11em
+  nav-label:
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.35
+rounded:
+  none: 0px
+  xs: 2px
+  sm: 4px
+  md: 8px
+  lg: 12px
+  xl: 16px
+spacing:
+  unit: 8px
+  hairline: 1px
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 32px
+  xxl: 48px
+  xxxl: 64px
+  sidebar-width: 300px
+  content-max: 1220px
+  content-readable: 780px
+  topbar-height: 72px
+  gutter-desktop: 64px
+  gutter-wide: 96px
+components:
+  page-shell:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text}"
+  page-margin:
+    backgroundColor: "{colors.margin-dark}"
+  topbar:
+    backgroundColor: "{colors.background}"
+    textColor: "{colors.text-strong}"
+    borderColor: "{colors.border-subtle}"
+    height: "{spacing.topbar-height}"
+  sidebar:
+    backgroundColor: "{colors.sidebar}"
+    textColor: "{colors.text-muted}"
+    borderColor: "{colors.border-subtle}"
+    width: "{spacing.sidebar-width}"
+  sidebar-item-active:
+    backgroundColor: "#2a160d"
+    textColor: "{colors.text-strong}"
+    borderColor: "{colors.accent}"
+    rounded: "{rounded.sm}"
+  content-panel:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    borderColor: "{colors.border-subtle}"
+  command-block:
+    backgroundColor: "{colors.surface-code}"
+    textColor: "{colors.text-strong}"
+    borderColor: "{colors.border}"
+    rounded: "{rounded.sm}"
+    padding: "12px 16px"
+  manual-card:
+    backgroundColor: "rgba(26, 17, 11, 0.72)"
+    textColor: "{colors.text}"
+    borderColor: "{colors.border}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.lg}"
+  note-card:
+    backgroundColor: "rgba(42, 26, 16, 0.48)"
+    textColor: "{colors.text}"
+    borderColor: "{colors.border}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+  table:
+    backgroundColor: "rgba(8, 6, 4, 0.44)"
+    textColor: "{colors.text}"
+    borderColor: "{colors.border}"
+  button-primary:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.text-strong}"
+    rounded: "{rounded.sm}"
+    padding: "10px 18px"
+  button-secondary:
+    backgroundColor: "transparent"
+    textColor: "{colors.text-strong}"
+    borderColor: "{colors.border-strong}"
+    rounded: "{rounded.sm}"
+    padding: "10px 18px"
+---
+
+# Betamax Analog Documentation Design System
+
+## Overview
+
+Betamax docs should feel like a dark 1980s analog technical manual for a VCR-era developer tool:
+warm, practical, structured, and tactile without becoming a fake physical binder or a hardware
+simulation.
+
+The homepage is allowed to be cinematic and physical. Interior documentation should be calmer: an
+operator manual that borrows the same Betamax colors, stripes, and analog warmth, while staying
+readable and task-focused.
+
+The target mood is:
+
+- **80s analog, not digital neon.** Think VCR packaging, service manuals, tape labels, matte
+  plastic, amber print, and warm paper ink.
+- **Manual-like, not app-like.** Documentation should prioritize sequence, reference, examples, and
+  scannability.
+- **Dark by default.** Light surfaces may exist only as rare callout/content variants; the primary
+  theme is dark.
+- **Subtle texture.** Use noise/grain only. Avoid visible repeating patterns, leather, carbon fiber,
+  brushed metal, paper stains, and excessive skeuomorphism.
+- **Betamax identity throughout.** The stripe motif is mandatory. Page-title stripe rules use three
+  colored bars: amber, orange, then red. Cream belongs to title text and the wordmark, not as a
+  fourth page-title stripe.
+
+Do not use the standalone `B` symbol as a recurring docs decoration. It can exist only if it is
+already part of a fixed asset, not as a generic icon, footer badge, or callout marker.
+
+## Colors
+
+The palette is warm, dark, and analog. It must never become blue-black cyberpunk or bright modern
+SaaS.
+
+- **Outer margin / page void:** use `margin-dark` or `background`. This area should be the darkest
+  part of the page so the content plane feels intentional.
+- **Main content surface:** use `surface` with subtle noise. It should be a little lighter than the
+  outer margin but still very dark.
+- **Sidebar:** use `sidebar`, slightly darker than content, separated by a thin warm border.
+- **Text:** use `text` for body and `text-strong` for headings. Body text must be cream/beige, never
+  pure white.
+- **Muted text:** use `text-muted` for captions, metadata, nav items, and secondary prose.
+- **Links and active states:** use `link`, `accent`, or `accent-orange`. Links may be underlined or
+  highlighted, but do not glow.
+- **Stripe sequence:** page-title rules use amber, orange, then red. Cream text may visually pair
+  with those three colored stripes in brand lockups.
+
+Never introduce saturated blue, purple, cyan, or neon green unless a code sample itself requires it.
+The docs chrome should remain brown/orange/red/cream.
+
+## Typography
+
+Use restrained typography that evokes a printed technical manual and a terminal-adjacent tool.
+
+- **Brand lockup:** always use the real Betamax wordmark lockup in the top-left header, or a direct
+  compact horizontal derivative of it. Do not rebuild the brand as generic text beside a standalone
+  stripe icon.
+- **Page titles:** use large warm cream display type with sturdy sans proportions. Titles should
+  feel like printed manual display text, not serif book typography or futuristic techno lettering.
+- **Body text:** may use a readable mono stack to preserve the technical manual feel. Keep body size
+  large enough for real reading.
+- **Labels:** use uppercase mono labels with letter spacing for nav groups, breadcrumbs, metadata,
+  and command labels.
+- **Code:** always monospace. Code should be among the highest-contrast elements on the page.
+
+Use no more than three font families. If no custom fonts are available, use system stacks from the
+tokens above rather than adding a new external dependency.
+
+## Layout
+
+Design primarily for a 16-inch MacBook viewport. At desktop widths, show the outer margins, the
+fixed left navigation, and a broad content plane. The design should not look like a narrow mobile
+page stretched across a large monitor.
+
+Desktop structure:
+
+1. **Top bar:** full-width, 72px high. Left: Betamax stripe hamburger + text lockup. Center or
+   mid-left: search. Right: simple text/icon links. No neon highlights.
+2. **Left sidebar:** fixed-width manual index rail around 300px. It is useful and should usually
+   stay visible on desktop.
+3. **Main content:** max width around 1220px. Align to the left of the content area, with breathing
+   room to the right. The content plane should be darker than mockups with cream paper, but slightly
+   lighter than the page margin.
+4. **Right TOC:** optional. Use it only for long reference pages. On short guide pages, prefer no
+   right TOC or a compact inline “At a glance” block.
+
+Spacing rules:
+
+- Use generous vertical rhythm around page headers, but keep body sections dense enough for docs.
+- Section rows can use two columns: prose/summary on the left, code/table/note on the right.
+- On pages like Quick Start, use numbered rows that make the workflow obvious.
+- On pages like Tape Reference, use broader tables and card-like reference sections.
+- At mobile/tablet widths, collapse the sidebar behind navigation and stack all section grids.
+
+The main content should not be centered like a marketing landing page unless the page is
+intentionally a splash/overview. Docs pages should feel like a manual index + work surface.
+
+## Elevation & Depth
+
+Depth comes from tonal layers, borders, inset panels, and very subtle shadows — not from heavy 3D
+realism.
+
+- Use thin warm borders (`border-subtle`, `border`, `border-strong`) to define structure.
+- Use `surface-raised` sparingly for cards, callouts, and command blocks.
+- Use low-opacity shadows only to separate the top bar, sidebar, and main cards. Avoid glossy
+  highlights.
+- Use subtle inner borders or inset shadows for command blocks and tables.
+- Texture should be a low-opacity random noise overlay. Avoid repeated wallpaper, leather, cloth,
+  carbon fiber, brushed metal, or visible pattern motifs.
+
+The content must feel tactile but still be a web document.
+
+## Shapes
+
+Use rectangular analog shapes with small corner radii.
+
+- Default radius: 4px to 8px.
+- Cards and larger panels: up to 12px.
+- Avoid pill-shaped modern SaaS controls except for tiny chips or keyboard key shapes.
+- Avoid over-rounded CRT-like panels and large soft glassmorphism.
+- Stripe bars should have square or barely rounded ends unless they are intentionally referencing
+  the homepage’s rounded stripe corner motif.
+
+## Components
+
+### Brand Header
+
+Non-negotiable: the docs header uses the Betamax logo lockup or a direct horizontal version of that
+lockup. The logo should look analog and printed, not glowing.
+
+Preferred header lockup:
+
+- Cream `Betamax` wordmark.
+- Three colored stripes associated directly with the wordmark.
+- Compact enough to fit the 72px docs header without becoming a generic icon.
+- Keep it top-left in desktop docs.
+
+Optional rectangular badge variant:
+
+- `Betamax` word above the red/orange/amber stripes inside a low-contrast badge.
+- Use only when it is the actual logo asset or a faithful crop/scale of it, not as a replacement
+  made from unrelated text and stripe shapes.
+
+Do not use a standalone `B` as a generic docs logo or decorative stamp.
+
+### Sidebar
+
+The sidebar should feel like a manual contents rail, not a default Starlight app sidebar.
+
+- Darker than the content surface.
+- Thin vertical warm border on the right.
+- Group headings in uppercase orange/amber labels.
+- Nav items are cream/muted text.
+- Active item: flat dark-brown fill, orange left rule or small orange indicator, cream text. No
+  glow, no gradient shine.
+- Keep spacing compact and readable.
+- Avoid large decorative stripe blocks at the bottom. If a footer mark is needed, use a small text
+  panel or one narrow stripe rule, not a large stack of stripes.
+
+### Page Header
+
+Each docs page should start with:
+
+1. Eyebrow/breadcrumb label such as `AUTHORING / TAPE FILES` or `START / QUICK START`.
+2. Large page title.
+3. A horizontal Betamax stripe rule under the title.
+4. One short description paragraph.
+
+Do not place the full Betamax logo inside every page title. The global header already carries the
+brand.
+
+The stripe rule should usually appear **under the page title**, not as a dominant top-of-page
+banner. It may span most of the content width. It should be strong enough to create identity but not
+so large that it competes with the content.
+
+### Guide Page Rows
+
+Use for Quick Start, Tape Files, Outputs, Themes, Generated Media, Terminal Testing, and similar
+teaching pages.
+
+- Use section rows with a left prose column and a right code/example/note column.
+- Numbered workflows should show a warm outlined number badge, not a bright digital pill.
+- Put the command or example close to the prose explaining it.
+- Prefer one clear command block per concept over many disconnected code blocks.
+- If a section is mostly prose, allow a side note card or compact checklist.
+
+### Reference Sections
+
+Use for Tape Reference, State JSON, CLI reference, settings tables, and command reference pages.
+
+- Use bordered reference modules with a heading, short explanation, and table/code content.
+- Icons may be used sparingly and should be line-based, warm cream/orange, and analog. Do not use
+  glowing digital icons.
+- Tables should be full-width inside their module when possible.
+- Long tables should prioritize legibility over decoration.
+
+### Command Blocks
+
+Command blocks are central to the docs and must be crisp.
+
+- Background: very dark, nearly black-brown.
+- Border: warm brown, 1px.
+- Text: cream, with commands and prompts optionally amber/orange.
+- Copy button: subtle outline/icon, no glowing hover.
+- Optional label: small uppercase `COMMAND`, `TAPE`, `SHELL`, or `OUTPUT` above or inside the block.
+- Do not put command blocks on bright cream unless a deliberate print-manual variant is being
+  created. Dark mode is primary.
+
+### Tables
+
+Tables should feel like technical reference sheets.
+
+- Header row uses uppercase orange/amber labels.
+- Cell text remains cream and readable.
+- Use thin warm dividers.
+- Avoid overly dense microtext. Increase row height before reducing font size below 13px.
+- For output tables, small left icons are acceptable if they improve scanning.
+
+### Notes, Tips, and Warnings
+
+Callouts should look like manual annotations.
+
+- Use subtle border-left or top rule in accent color.
+- Use a muted surface, not a bright colored fill.
+- Label with `NOTE`, `TIP`, `WARNING`, or `COMPATIBILITY` in uppercase mono.
+- Keep iconography minimal and non-glowing.
+
+### Stripes
+
+The stripe motif is mandatory but should be systematic.
+
+Good uses:
+
+- Under page titles.
+- Thin divider in the top bar or content header.
+- Small section cap on important cards.
+- Tiny nav indicator or rule.
+- Small footer detail.
+
+Avoid:
+
+- Large decorative stripe stacks in the bottom-left sidebar.
+- Repeating stripe wallpaper.
+- Stripes that overpower the content.
+- Stripes used as neon light beams.
+
+Page-title stripe order should be amber, orange, then red. Use cream as nearby title or wordmark
+text, not as a fourth line in the rule.
+
+## Page Type Guidance
+
+### Quick Start
+
+Goal: make Betamax usage obvious in under one minute.
+
+Recommended structure:
+
+1. Page header with stripe rule and short compatibility note.
+2. Numbered workflow sections: Install, Repository Software, Create A Tape, Validate Tapes, List
+   Themes, Repository Examples.
+3. For each step, put prose on the left and the command block on the right.
+4. Use notes for ffmpeg, Zig/mise, and validation behavior only where needed.
+5. Do not include a right TOC unless the page becomes substantially longer.
+
+### Tape Files
+
+Goal: explain the authoring model.
+
+Recommended structure:
+
+- Intro paragraph.
+- File Structure section with prose + a compact tape example.
+- Tokenization section with bullets + examples.
+- Synchronization and Hidden Work sections as rows with code and notes.
+- Use right-side note cards when a rule is important.
+
+### Outputs
+
+Goal: help users choose output formats.
+
+Recommended structure:
+
+- Big output table near the top.
+- Three explanatory sections: Choosing Outputs, Video Encoding, Checkpoints.
+- Keep the table readable and wide.
+- Use small output icons only if they make scanning easier.
+
+### Themes And Styling
+
+Goal: explain theme lookup and rendering controls.
+
+Recommended structure:
+
+- Theme lookup command block.
+- Palette preview cards for common themes if available.
+- Settings tables grouped by Layout, Frame Decoration, Timing/Cursor.
+- Avoid page-wide color chaos; theme swatches should be controlled accents.
+
+### Examples
+
+Goal: show real tape files and previews.
+
+Recommended structure:
+
+- Example index table with tape name, demonstrates, useful docs.
+- Preview cards for GIFs/screenshots.
+- Keep previews in dark frames with small captions.
+- Do not use the large homepage hardware frame on every example.
+
+### Tape Reference
+
+Goal: dense but navigable reference.
+
+Recommended structure:
+
+- Page header with stripe rule.
+- Optional compact metadata card near the top.
+- Bordered modules for Parsing Rules, Outputs, Settings, Command Reference, Key Commands, CLI
+  Commands.
+- Right TOC is acceptable here because the page is long.
+- Tables should be large enough for real reading.
+
+## Content Editing Guidance for Codex
+
+When refactoring MDX for this design system:
+
+- Preserve the existing technical facts and commands.
+- Improve structure by grouping prose, code, notes, and tables into reusable components.
+- Prefer semantic components over one-off HTML when possible.
+- Do not invent unsupported Betamax commands.
+- Do not reintroduce `record`, `serve`, or `publish` as primary workflows.
+- Make Quick Start procedural and concise.
+- Make reference pages modular and table-friendly.
+- Keep examples copyable.
+- Keep docs under `/betamax` base path compatible with relative links.
+
+Useful component names to create or reuse:
+
+- `DocsPageHeader`
+- `BetamaxStripes`
+- `ManualSection`
+- `GuideStep`
+- `CommandBlock`
+- `ManualNote`
+- `ReferenceModule`
+- `SpecTable`
+- `ExamplePreview`
+- `PageNav`
+
+These components should map cleanly to Starlight/Astro/MDX. If Starlight defaults conflict with this
+design, override theme CSS rather than rewriting all content unless the page structure genuinely
+needs custom components.
+
+## Do's and Don'ts
+
+### Do
+
+- Do keep dark mode as the primary experience.
+- Do use the stripe hamburger + Betamax text lockup in the top-left header.
+- Do use the stripe rule under page titles.
+- Do keep the main content darker than cream-paper mockups.
+- Do make the page margin/outer background darker than the content surface.
+- Do use subtle noise texture only.
+- Do use warm cream text and analog orange/red accents.
+- Do make code blocks and tables highly readable.
+- Do use left sidebar grouping that feels like a manual index.
+- Do let page layout vary by content type.
+
+### Don't
+
+- Don't use digital neon, cyan glow, glossy highlights, or futuristic UI effects.
+- Don't use leather, heavy binder realism, obvious paper stains, or visible repeating patterns.
+- Don't put terminal hardware around interior docs content.
+- Don't use the standalone `B` symbol as a recurring ornament.
+- Don't add a large stripe block to the sidebar bottom.
+- Don't make cream/light mode the primary docs appearance.
+- Don't let the right TOC stay by default on short pages if it adds clutter.
+- Don't center all docs content like a marketing homepage.
+- Don't reduce tables or code below comfortable reading sizes.
+
+## Accessibility
+
+- Maintain at least WCAG AA contrast for normal body text.
+- Avoid placing small cream text over high-noise or high-contrast stripe backgrounds.
+- Do not use color alone to communicate state; pair active states with position, border, icon, or
+  label.
+- Keep focus outlines visible and warm, e.g. amber outline with sufficient contrast.
+- Respect reduced motion. Any stripe shimmer, hover movement, or texture animation should be
+  disabled under `prefers-reduced-motion`.
+
+## Implementation Notes
+
+- Use CSS custom properties for all colors and spacing. Map these tokens into Starlight variables
+  where possible.
+- Add one global noise overlay using a small CSS gradient/noise asset or pseudo-element at very low
+  opacity. Do not use a visible repeating texture.
+- Use `background-color` layering rather than strong box shadows for hierarchy.
+- Keep the homepage-specific terminal hardware and hero assets scoped to the splash page.
+- Create custom MDX components only where the content structure benefits: guide steps, reference
+  modules, command blocks, note cards, and page headers.

--- a/site/src/content/docs/authoring/tape-files.mdx
+++ b/site/src/content/docs/authoring/tape-files.mdx
@@ -3,18 +3,32 @@ title: Tape Files
 description: How Betamax parses, validates, and executes terminal capture scripts.
 ---
 
-A tape is a small script that describes one terminal session. It names
-[`Output`](../../reference/tape-reference/#output-path) artifacts, configures the terminal, starts a
-shell in a PTY, sends text and keys, waits for stable terminal states, and optionally writes
-checkpoint [`Screenshot`](../../reference/tape-reference/#screenshot-pathpng) or
-[`State`](../../reference/tape-reference/#state-pathjson) files.
+<div class="bm-manual-page bm-tape-files">
 
-Start here for authoring concepts. Use the [Tape Reference](../../reference/tape-reference/) for
-the exact command surface and [Examples](../../examples/) for copyable tapes.
+<div class="bm-manual-lede">
+
+A tape file describes one terminal capture session. It lists outputs, startup settings, terminal
+actions, waits, checkpoints, and metadata in the order Betamax should execute them.
+
+</div>
+
+<section class="bm-manual-row bm-manual-row-top" aria-labelledby="file-structure">
+<div class="bm-manual-copy">
+
+## File Structure
+
+Most tapes divide into three parts:
+
+1. Outputs, requirements, environment, and startup settings.
+1. Ordered terminal actions such as typing, key presses, and waits.
+1. Optional screenshots, state captures, hidden cleanup, and shell exit.
+
+</div>
+
+<div class="bm-manual-code">
 
 ```text
 Output examples/output/basic.gif
-
 Require printf
 
 Set Shell "bash"
@@ -28,49 +42,67 @@ Enter
 Wait+Screen "hello"
 ```
 
-## File Structure
+</div>
 
-Most tapes follow this order:
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Notes</p>
+  <p>
+    Startup commands must appear before runtime commands because Betamax needs the shell,
+    terminal dimensions, theme, environment, and output requirements before PTY startup.
+  </p>
+</aside>
+</section>
 
-1. Declare [`Output`](../../reference/tape-reference/#output-path) files.
-1. Declare [`Require`](../../reference/tape-reference/#require-program) checks for external
-   commands used by the tape.
-1. Apply [`Env`](../../reference/tape-reference/#env-key-value) and
-   [`Set`](../../reference/tape-reference/#set-name-value) startup configuration.
-1. Run terminal actions such as [`Type`](../../reference/tape-reference/#typeduration-text), key
-   presses, [waits](../../reference/tape-reference/#waitduration-regextext), screenshots, and state
-   captures.
-1. Hide trailing cleanup with [`Hide`](../../reference/tape-reference/#hide), then type `exit` if
-   the shell should close cleanly.
-
-Startup commands must appear before runtime commands. This is intentional: Betamax needs to know
-the shell argv, terminal dimensions, theme, environment, and output requirements before it starts
-the PTY or creates capture state.
+<section class="bm-manual-row bm-manual-row-top" aria-labelledby="tokenization">
+<div class="bm-manual-copy">
 
 ## Tokenization
 
 Tapes use shell-like tokenization for each non-comment line. Quote strings that contain spaces,
-newlines, regex characters, ANSI escapes, or shell syntax:
+newlines, regex characters, ANSI escapes, or shell syntax.
+
+- Blank lines are ignored.
+- Lines whose trimmed form starts with `#` are comments.
+- Multiple commands may appear on one line.
+- One command per line is usually easier to review by hand.
+
+</div>
+
+<div class="bm-manual-code">
 
 ```text
 Type "printf 'hello from betamax\n'"
 Wait+Screen "hello from betamax"
 Wait+Screen "/item-[0-9]+/"
+
+Type "printf 'done\n'"
+Enter
+Wait+Screen "done"
 ```
 
-Blank lines are ignored. Lines whose trimmed form starts with `#` are comments. Multiple commands
-may appear on one line, which is useful for compact generated tapes:
+</div>
 
-```text
-Type "printf 'done\n'" Enter Wait+Screen "done"
-```
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Token Rules</p>
+  <ul>
+    <li>Quote values with spaces.</li>
+    <li>Use regex waits for changing output.</li>
+    <li>Keep generated tapes compact only when review does not matter.</li>
+  </ul>
+</aside>
+</section>
 
-For hand-written tapes, one command per line is usually easier to review.
+<section class="bm-manual-row bm-manual-row-split" aria-labelledby="synchronization">
+<div class="bm-manual-copy">
 
 ## Synchronization
 
 Prefer waits over long sleeps. A sleep records whatever happens for a fixed amount of time; a wait
-records until the expected terminal text exists or the timeout expires.
+records until expected terminal text exists or the timeout expires.
+
+</div>
+
+<div class="bm-manual-code bm-compact-code">
 
 ```text
 Type "cargo test --quiet"
@@ -78,17 +110,29 @@ Enter
 Wait+Screen "test result:"
 ```
 
-Use [`Wait+Line`](../../reference/tape-reference/#waitlineduration-regextext) or bare
-[`Wait`](../../reference/tape-reference/#waitduration-regextext) for prompts. Use
-[`Wait+Screen`](../../reference/tape-reference/#waitscreenduration-regextext) for command output,
-full-screen TUIs, and text that may not be on the cursor line. Use regex waits when the output
-contains changing numbers, paths, durations, or identifiers.
+</div>
+
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Tip</p>
+  <p>
+    Use <a href="../../reference/tape-reference/#waitscreenduration-regextext">Wait+Screen</a>
+    for command output and full-screen TUIs.
+  </p>
+</aside>
+</section>
+
+<section class="bm-manual-row bm-manual-row-split" aria-labelledby="hidden-work">
+<div class="bm-manual-copy">
 
 ## Hidden Work
 
 [`Hide`](../../reference/tape-reference/#hide) and [`Show`](../../reference/tape-reference/#show)
-are visibility controls, not execution controls. Hidden commands still run in the PTY, still update
-terminal state, and can still be waited on. They simply do not append frames to animated outputs.
+are visibility controls, not execution controls. Hidden commands still run in the PTY, update
+terminal state, and can be waited on.
+
+</div>
+
+<div class="bm-manual-code bm-compact-code">
 
 ```text
 Hide
@@ -96,14 +140,21 @@ Type "cargo build --quiet"
 Enter
 Wait
 Show
-
-Type "my-cli --demo"
-Enter
-Wait+Screen "Ready"
 ```
 
-[`Show`](../../reference/tape-reference/#show) immediately captures the current terminal frame. That
-avoids a visible flicker from a hidden shell prompt to the useful output.
+</div>
+
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Remember</p>
+  <p>
+    <code>Show</code> immediately captures the current terminal frame, avoiding a visible
+    flicker from setup work to useful output.
+  </p>
+</aside>
+</section>
+
+<section class="bm-manual-row bm-manual-row-split" aria-labelledby="outputs-during-a-tape">
+<div class="bm-manual-copy">
 
 ## Outputs During A Tape
 
@@ -112,23 +163,39 @@ execution. [`Screenshot`](../../reference/tape-reference/#screenshot-pathpng) an
 [`State`](../../reference/tape-reference/#state-pathjson) write checkpoint artifacts immediately at
 their position in the tape.
 
+</div>
+
+<div class="bm-manual-code bm-compact-code">
+
 ```text
 Wait+Screen "Saved profile"
 Screenshot target/snapshots/profile.png
 State target/snapshots/profile.state.json
 ```
 
-For testing, pair a wait with a checkpoint state file. For documentation, pair a GIF with a final
-PNG or checkpoint screenshot so reviewers can inspect one frame without opening an animation.
+</div>
+
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Review</p>
+  <p>
+    Pair a GIF with a final PNG or checkpoint screenshot so reviewers can inspect one frame
+    without opening an animation.
+  </p>
+</aside>
+</section>
+
+<section class="bm-manual-row bm-manual-row-split" aria-labelledby="shell-defaults">
+<div class="bm-manual-copy">
 
 ## Shell Defaults
 
 For common shells such as `bash`, `zsh`, and `fish`, Betamax starts a clean recording-oriented
 environment where possible. The default prompt behavior aims for VHS-like output: a simple `>`
-prompt rather than host-specific prompts such as `bash-5.3$`. See
-[Differences From VHS](../../reference/vhs-differences/) for the compatibility boundary.
+prompt rather than host-specific prompts such as `bash-5.3$`.
 
-Set `Shell` explicitly when a tape depends on shell syntax:
+</div>
+
+<div class="bm-manual-code bm-compact-code">
 
 ```text
 Set Shell "bash"
@@ -136,5 +203,15 @@ Set Shell "zsh -f"
 Set Shell "fish --private"
 ```
 
-Shell argv is split with shell-like rules, so a single `Set Shell` string can contain the program
-and arguments.
+</div>
+
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Compatibility</p>
+  <p>
+    See <a href="../../reference/vhs-differences/">Differences From VHS</a> for the compatibility
+    boundary.
+  </p>
+</aside>
+</section>
+
+</div>

--- a/site/src/content/docs/quick-start.mdx
+++ b/site/src/content/docs/quick-start.mdx
@@ -3,33 +3,73 @@ title: Quick Start
 description: Install Betamax and render your first tape.
 ---
 
+<div class="bm-quickstart">
+
+<div class="bm-guide-lede">
+
 Betamax currently supports macOS and Linux. Windows is not supported because the upstream
 [`libghostty-vt-sys`](../reference/vhs-differences/) native build does not support Windows.
 
+</div>
+
+<nav class="bm-step-index" aria-label="Quick Start steps">
+  <a href="#install">
+    <span>01</span>
+    <strong>Install</strong>
+    <small>Get the CLI.</small>
+  </a>
+  <a href="#repository-software">
+    <span>02</span>
+    <strong>Repo Tools</strong>
+    <small>Set up development.</small>
+  </a>
+  <a href="#create-a-tape">
+    <span>03</span>
+    <strong>Create</strong>
+    <small>Write and render.</small>
+  </a>
+  <a href="#validate-tapes">
+    <span>04</span>
+    <strong>Validate</strong>
+    <small>Check syntax first.</small>
+  </a>
+  <a href="#list-themes">
+    <span>05</span>
+    <strong>Themes</strong>
+    <small>Find style names.</small>
+  </a>
+  <a href="#repository-examples">
+    <span>06</span>
+    <strong>Examples</strong>
+    <small>Render fixtures.</small>
+  </a>
+</nav>
+
+<section class="bm-step" aria-labelledby="install">
+<div class="bm-step-copy">
+
 ## Install
 
-Install the CLI with Homebrew from [joshka/homebrew-tap][homebrew-tap]:
+Install the CLI with Homebrew from [joshka/homebrew-tap][homebrew-tap]. If Homebrew requires trusted
+taps, trust the formula first.
+
+Rust users can install from crates.io with [cargo-binstall][cargo-binstall].
+
+GIF, PNG, screenshot, and state JSON outputs are written in process. MP4 and WebM output require
+[ffmpeg](../authoring/outputs/#video-encoding) on `PATH`.
+
+</div>
+<div class="bm-step-action">
 
 ```sh
 brew install joshka/tap/betamax
-```
-
-If Homebrew requires trusted taps, trust the formula first:
-
-```sh
 brew trust --formula joshka/tap/betamax
 ```
-
-Or install Rust and Cargo with [rustup][rustup], then install from crates.io with
-[cargo-binstall][cargo-binstall]:
 
 ```sh
 cargo install cargo-binstall
 cargo binstall betamax
 ```
-
-GIF, PNG, screenshot, and state JSON outputs are written in process. MP4 and WebM output require
-[ffmpeg](../authoring/outputs/#video-encoding) on `PATH`:
 
 ```sh
 # macOS
@@ -40,68 +80,123 @@ sudo apt-get update
 sudo apt-get install ffmpeg
 ```
 
+<aside class="bm-step-note" aria-label="Install notes">
+  <p class="bm-note-label">Notes</p>
+  <p>
+    Homebrew is the shortest path. Cargo works well when Rust is already part of the
+    machine.
+  </p>
+</aside>
+</div>
+</section>
+
+<section class="bm-step" aria-labelledby="repository-software">
+<div class="bm-step-copy">
+
 ## Repository Software
 
-The checked-in examples and development commands need:
+The checked-in examples and development commands need Rust and Cargo from [rustup][rustup],
+[mise][mise] for the repository toolchain, [pnpm][pnpm] for the documentation site, and
+[ffmpeg](../authoring/outputs/#video-encoding) only when rendering MP4 or WebM outputs.
 
-- Rust and Cargo, usually from [rustup][rustup].
-- [mise][mise] for the repository toolchain, especially Zig 0.15.2.
-- [pnpm][pnpm] for the documentation site and site checks.
-- [ffmpeg](../authoring/outputs/#video-encoding) only when rendering MP4 or WebM outputs.
+The important non-Rust tool is Zig 0.15.2. Betamax builds against the vendored `libghostty-vt-sys`
+crate, and that native Ghostty build currently fails with newer Zig releases such as 0.16.
 
-Install the repository tools and docs dependencies with:
+mise is the documented path because it is small and works across the repository today. Other
+toolchain managers can work too, including [Nix][nix] or a manually installed [Zig][zig] 0.15.2 on
+`PATH`. PRs that document another reproducible setup are welcome.
+
+</div>
+<div class="bm-step-action">
 
 ```sh
 mise install
 pnpm install
 ```
 
-The important non-Rust tool is Zig 0.15.2. Betamax builds against the vendored
-`libghostty-vt-sys` crate, and that native Ghostty build currently fails with newer Zig releases
-such as 0.16. The repository pins Zig 0.15.2 in `.mise.toml`, so `mise run ...` commands use the
-version Ghostty expects.
+<aside class="bm-step-note" aria-label="Repository software notes">
+  <p class="bm-note-label">Toolchain</p>
+  <p>
+    The repository pins Zig 0.15.2 in <code>.mise.toml</code>, so
+    <code>mise run ...</code> commands use the version Ghostty expects.
+  </p>
+</aside>
+</div>
+</section>
 
-mise is the documented path because it is small and works across the repository today. Other
-toolchain managers can work too, including [Nix][nix] or a manually installed [Zig][zig] 0.15.2 on
-`PATH`. PRs that document another reproducible setup are welcome.
+<section class="bm-step" aria-labelledby="create-a-tape">
+<div class="bm-step-copy">
 
 ## Create A Tape
 
+Create a starter tape, render it, and optionally append an extra
+[`Output`](../reference/tape-reference/#output-path) from the CLI without editing the tape.
+
+The starter tape includes a compact command summary and writes `demo.gif` by default. The CLI output
+path is appended as another [`Output`](../reference/tape-reference/#output-path) command. It does
+not replace outputs already in the tape.
+
+</div>
+<div class="bm-step-action">
+
 ```sh
 betamax new demo.tape
-```
-
-The starter tape includes a compact command summary and writes `demo.gif` by default. Render it
-with:
-
-```sh
 betamax run demo.tape
-```
-
-Append an extra [`Output`](../reference/tape-reference/#output-path) from the CLI without editing
-the tape:
-
-```sh
 betamax run demo.tape --output target/demo.png
 ```
 
-The output path is appended as another [`Output`](../reference/tape-reference/#output-path)
-command. It does not replace outputs already in the tape.
+<aside class="bm-step-note" aria-label="Create a tape notes">
+  <p class="bm-note-label">Output</p>
+  <p>
+    CLI-provided outputs append to the tape for that run. They do not rewrite the source
+    file.
+  </p>
+</aside>
+</div>
+</section>
+
+<section class="bm-step" aria-labelledby="validate-tapes">
+<div class="bm-step-copy">
 
 ## Validate Tapes
 
-Validate one tape or a group of tapes without rendering:
+Validate one tape or a group of tapes without rendering.
+
+Validation parses syntax and enforces command ordering. It does not start a shell, load a theme, run
+[`Require`](../reference/tape-reference/#require-program) checks, or write output files. Use
+`betamax run` for a full execution check.
+
+</div>
+<div class="bm-step-action">
 
 ```sh
 betamax validate demo.tape
 betamax validate "examples/*.tape"
 ```
 
-Validation parses syntax and enforces command ordering. It does not start a shell, load a theme, run
-[`Require`](../reference/tape-reference/#require-program) checks, or write output files. Use
-`betamax run` for a full execution check.
+<aside class="bm-step-note" aria-label="Validate tapes notes">
+  <p class="bm-note-label">Fast Check</p>
+  <p>
+    Validation is structural. It is meant to catch ordering and parsing problems before a
+    PTY starts.
+  </p>
+</aside>
+</div>
+</section>
+
+<section class="bm-step" aria-labelledby="list-themes">
+<div class="bm-step-copy">
 
 ## List Themes
+
+List theme names and use the exact value with
+[`Set Theme "..."`](../reference/tape-reference/#settings).
+
+See [Themes And Styling](../authoring/themes/) for lookup behavior, layout settings, and frame
+decoration.
+
+</div>
+<div class="bm-step-action">
 
 ```sh
 betamax themes
@@ -109,13 +204,29 @@ betamax themes --json
 betamax themes --markdown
 ```
 
-Use the exact theme name with [`Set Theme "..."`](../reference/tape-reference/#settings). See
-[Themes And Styling](../authoring/themes/) for lookup behavior, layout settings, and frame
-decoration.
+<aside class="bm-step-note" aria-label="List themes notes">
+  <p class="bm-note-label">Remember</p>
+  <p>
+    Theme names are matched by name. Copy the exact value into
+    <code>Set Theme "..."</code>.
+  </p>
+</aside>
+</div>
+</section>
+
+<section class="bm-step" aria-labelledby="repository-examples">
+<div class="bm-step-copy">
 
 ## Repository Examples
 
-Clone the repository to render the checked-in examples:
+Clone the repository to render the checked-in examples.
+
+Rendered outputs are written under `examples/output` and copied to `target/betamax-examples` for
+local inspection. The [Examples](../examples/) page explains what each tape demonstrates. The
+[Tape Reference](../reference/tape-reference/) documents every command and setting.
+
+</div>
+<div class="bm-step-action">
 
 ```sh
 git clone https://github.com/joshka/betamax
@@ -125,9 +236,17 @@ pnpm install
 mise run render-examples
 ```
 
-Rendered outputs are written under `examples/output` and copied to `target/betamax-examples` for
-local inspection. The [Examples](../examples/) page explains what each tape demonstrates. The
-[Tape Reference](../reference/tape-reference/) documents every command and setting.
+<aside class="bm-step-note" aria-label="Repository examples notes">
+  <p class="bm-note-label">Where Files Go</p>
+  <p>
+    Example renders land under <code>examples/output</code> and are copied to
+    <code>target/betamax-examples</code> for inspection.
+  </p>
+</aside>
+</div>
+</section>
+
+</div>
 
 [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
 [homebrew-tap]: https://github.com/joshka/homebrew-tap

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -25,7 +25,7 @@
   margin-inline: auto;
 }
 
-:root[data-theme='light'] {
+:root[data-theme="light"] {
   --sl-color-white: #151211;
   --sl-color-gray-1: #211b19;
   --sl-color-gray-2: #3b302b;
@@ -46,72 +46,114 @@
 
 .page {
   background:
-    radial-gradient(circle at 18% 12%, rgba(122, 42, 18, 0.07), transparent 34rem),
-    radial-gradient(circle at 72% 4%, rgba(112, 72, 39, 0.06), transparent 30rem);
+    radial-gradient(
+      circle at 18% 12%,
+      rgba(122, 42, 18, 0.07),
+      transparent 34rem
+    ),
+    radial-gradient(
+      circle at 72% 4%,
+      rgba(112, 72, 39, 0.06),
+      transparent 30rem
+    );
 }
 
-:root:not([data-theme='light']) main a code {
+:root:not([data-theme="light"]) main a code {
   color: var(--sl-color-accent-high);
 }
 
-:root:not([data-theme='light']) .page > .header {
+:root:not([data-theme="light"]) .page > .header {
   border-bottom: 1px solid #151211;
   background: #171312;
   box-shadow: inset 0 -1px rgba(0, 0, 0, 0.35);
 }
 
-:root:not([data-theme='light']) .header .header {
+:root:not([data-theme="light"]) .header .header {
   background: transparent;
 }
 
-:root:not([data-theme='light']) .social-icons a::after {
-  content: 'GitHub';
+:root:not([data-theme="light"]) body:has(.betamax-hero) .social-icons a::after {
+  content: "GitHub";
   margin-inline-start: 0.45rem;
   color: var(--sl-color-gray-2);
   font-size: 0.92rem;
   font-weight: 700;
 }
 
-:root:not([data-theme='light']) .site-title {
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .social-icons
+  a::after {
+  content: none;
+}
+
+:root:not([data-theme="light"]) body:not(:has(.betamax-hero)) .social-icons a {
+  display: inline-grid;
+  place-items: center;
+  width: 2.55rem;
+  height: 2.55rem;
+  padding: 0;
+  color: var(--sl-color-text-accent);
+  line-height: 1;
+  text-decoration: none;
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .social-icons
+  a:hover {
+  color: #ffd6a4;
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .social-icons
+  svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+:root:not([data-theme="light"]) .site-title {
   gap: 0.55rem;
   color: var(--sl-color-gray-1);
   font-family: var(--sl-font-system);
   font-size: 1.15rem;
   font-weight: 800;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 
-:root:not([data-theme='light']) .site-title::before {
-  content: '';
+:root:not([data-theme="light"]) .site-title::before {
+  content: "";
   display: block;
   flex: none;
   width: 2.15rem;
   height: 1.45rem;
-  background: url('/betamax/assets/betamax-nav-mark.svg') center / contain no-repeat;
+  background: url("/betamax/assets/betamax-nav-mark.svg") center / contain
+    no-repeat;
   box-shadow: 0 0 1.2rem rgba(227, 107, 44, 0.1);
 }
 
-:root:not([data-theme='light']) .sidebar-pane {
+:root:not([data-theme="light"]) .sidebar-pane {
   border-right-color: #151211;
   background: #1b1614;
 }
 
-:root:not([data-theme='light']) .main-pane {
+:root:not([data-theme="light"]) .main-pane {
   border-inline: 0;
   background: transparent;
 }
 
-:root:not([data-theme='light']) .right-sidebar {
+:root:not([data-theme="light"]) .right-sidebar {
   border-left-color: #4a301f;
   background: rgba(12, 9, 8, 0.42);
 }
 
-:root:not([data-theme='light']) .content-panel {
+:root:not([data-theme="light"]) .content-panel {
   border-bottom-color: #2a1b13;
   background: transparent;
 }
 
-:root:not([data-theme='light']) [aria-current='page'] {
+:root:not([data-theme="light"]) [aria-current="page"] {
   color: #201109;
   background: linear-gradient(180deg, #ee8d49, #d55724);
   box-shadow:
@@ -119,28 +161,28 @@
     inset 0 -1px rgba(87, 27, 13, 0.45);
 }
 
-:root:not([data-theme='light']) :is(h1, h2, h3) {
+:root:not([data-theme="light"]) :is(h1, h2, h3) {
   color: #f4e2c2;
 }
 
-:root:not([data-theme='light']) main :not(pre) > code {
+:root:not([data-theme="light"]) main :not(pre) > code {
   color: #f0d0a0;
   background: #3b281c;
 }
 
-:root:not([data-theme='light']) main :not(pre) > a code {
+:root:not([data-theme="light"]) main :not(pre) > a code {
   color: var(--sl-color-accent-high);
 }
 
 /* Code blocks: match the deployed Expressive Code styling (lighter,
    lifted warm-brown body so blocks separate cleanly from the page). */
-:root:not([data-theme='light']) {
+:root:not([data-theme="light"]) {
   --ec-frm-edBg: #261f1d;
   --ec-frm-trmBg: #261f1d;
   --ec-brdCol: color-mix(in srgb, #4b3a31, transparent 25%);
 }
 
-:root:not([data-theme='light']) main table :is(th, td) {
+:root:not([data-theme="light"]) main table :is(th, td) {
   border-color: #4a301f;
 }
 
@@ -154,8 +196,16 @@ main:has(.betamax-hero) > .content-panel:first-child {
 
 main:has(.betamax-hero) {
   background:
-    radial-gradient(circle at 67% 18%, rgba(214, 103, 36, 0.16), transparent 22rem),
-    radial-gradient(circle at 22% 12%, rgba(160, 55, 28, 0.08), transparent 20rem),
+    radial-gradient(
+      circle at 67% 18%,
+      rgba(214, 103, 36, 0.16),
+      transparent 22rem
+    ),
+    radial-gradient(
+      circle at 22% 12%,
+      rgba(160, 55, 28, 0.08),
+      transparent 20rem
+    ),
     linear-gradient(180deg, #0b0b0a 0%, #100d0a 42%, #0b0806 100%);
 }
 
@@ -172,7 +222,7 @@ main:has(.betamax-hero) {
   position: relative;
 }
 
-:root[data-theme='light'] .betamax-hero {
+:root[data-theme="light"] .betamax-hero {
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.75), transparent 32%),
     linear-gradient(180deg, rgba(255, 218, 188, 0.82), rgba(226, 210, 181, 0.5));
@@ -201,8 +251,14 @@ main:has(.betamax-hero) {
   filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.55));
 }
 
-:root[data-theme='light'] .betamax-hero h1 {
-  background: linear-gradient(180deg, #fff 4%, #b4a37f 38%, #5a493c 52%, #e6c07f 92%);
+:root[data-theme="light"] .betamax-hero h1 {
+  background: linear-gradient(
+    180deg,
+    #fff 4%,
+    #b4a37f 38%,
+    #5a493c 52%,
+    #e6c07f 92%
+  );
   -webkit-background-clip: text;
   background-clip: text;
   text-shadow: 0 12px 28px rgba(84, 57, 35, 0.24);
@@ -228,7 +284,7 @@ main:has(.betamax-hero) {
   line-height: 1.55;
 }
 
-:root[data-theme='light'] .betamax-tagline {
+:root[data-theme="light"] .betamax-tagline {
   color: #3b302b;
 }
 
@@ -244,7 +300,8 @@ main:has(.betamax-hero) {
   align-items: center;
   min-height: 2.8rem;
   padding: 0.62rem 1.3rem;
-  border: 1px solid color-mix(in srgb, var(--sl-color-accent) 72%, var(--sl-color-hairline));
+  border: 1px solid
+    color-mix(in srgb, var(--sl-color-accent) 72%, var(--sl-color-hairline));
   border-radius: 12px;
   color: var(--sl-color-gray-1);
   font-weight: 700;
@@ -261,12 +318,12 @@ main:has(.betamax-hero) {
     0 1px 10px rgba(224, 90, 36, 0.25);
 }
 
-:root[data-theme='light'] .betamax-button {
+:root[data-theme="light"] .betamax-button {
   color: #241a16;
   background: rgba(255, 247, 232, 0.72);
 }
 
-:root[data-theme='light'] .betamax-button-primary {
+:root[data-theme="light"] .betamax-button-primary {
   color: #fff7e8;
 }
 
@@ -283,14 +340,26 @@ main:has(.betamax-hero) {
 
 /* Ambient warm glow behind the cassette + warm floor reflection glow */
 .betamax-demo::after {
-  content: '';
+  content: "";
   position: absolute;
   z-index: 0;
   inset: 0% -8% -30% -8%;
   background:
-    radial-gradient(ellipse at 56% 32%, rgba(224, 109, 41, 0.22), transparent 52%),
-    radial-gradient(ellipse at 38% 24%, rgba(160, 55, 28, 0.12), transparent 56%),
-    radial-gradient(ellipse 52% 20% at 50% 80%, rgba(228, 112, 44, 0.34), transparent 72%);
+    radial-gradient(
+      ellipse at 56% 32%,
+      rgba(224, 109, 41, 0.22),
+      transparent 52%
+    ),
+    radial-gradient(
+      ellipse at 38% 24%,
+      rgba(160, 55, 28, 0.12),
+      transparent 56%
+    ),
+    radial-gradient(
+      ellipse 52% 20% at 50% 80%,
+      rgba(228, 112, 44, 0.34),
+      transparent 72%
+    );
   filter: blur(1.4rem);
   opacity: 0.95;
   pointer-events: none;
@@ -303,7 +372,7 @@ main:has(.betamax-hero) {
    element is flipped, the "solid" mask stop sits at the bottom (100%) which,
    after the flip, becomes the contact line at the top. */
 .betamax-demo::before {
-  content: '';
+  content: "";
   position: absolute;
   z-index: 1;
   inset: auto 0 auto 0;
@@ -313,7 +382,8 @@ main:has(.betamax-hero) {
   top: calc(100% - 40px);
   width: 100%;
   aspect-ratio: 472 / 330;
-  background: url('/betamax/assets/betamax-hero-tape.png') center top / contain no-repeat;
+  background: url("/betamax/assets/betamax-hero-tape.png") center top / contain
+    no-repeat;
   transform: scaleY(-1);
   transform-origin: center;
   -webkit-mask-image: linear-gradient(
@@ -356,11 +426,15 @@ main:has(.betamax-hero) {
 }
 
 .betamax-terminal-demo::before {
-  content: '';
+  content: "";
   position: absolute;
   z-index: 0;
   inset: 60% 6% 0;
-  background: radial-gradient(ellipse at 50% 50%, rgba(224, 109, 41, 0.2), transparent 68%);
+  background: radial-gradient(
+    ellipse at 50% 50%,
+    rgba(224, 109, 41, 0.2),
+    transparent 68%
+  );
   filter: blur(1rem);
   pointer-events: none;
 }
@@ -401,7 +475,8 @@ main:has(.betamax-hero) {
   margin: 0;
   min-height: 16rem;
   padding: 1.4rem 1.25rem 1.25rem;
-  border: 1px solid color-mix(in srgb, var(--sl-color-hairline) 74%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 74%, transparent);
   border-radius: 10px;
   color: inherit;
   background:
@@ -409,7 +484,7 @@ main:has(.betamax-hero) {
     rgba(15, 10, 7, 0.72);
 }
 
-:root[data-theme='light'] .feature-grid section {
+:root[data-theme="light"] .feature-grid section {
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.74), transparent 48%),
     rgba(244, 231, 207, 0.78);
@@ -456,7 +531,8 @@ main:has(.betamax-hero) {
   align-items: center;
   margin-top: auto;
   padding-top: 1.1rem;
-  border-top: 1px solid color-mix(in srgb, var(--sl-color-hairline) 38%, transparent);
+  border-top: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 38%, transparent);
   color: var(--sl-color-gray-3);
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
   font-size: 0.72rem;
@@ -525,7 +601,8 @@ main:has(.betamax-hero) {
 }
 
 .feature-grid .bm-chipset kbd + kbd {
-  border-left: 1px solid color-mix(in srgb, var(--sl-color-hairline) 70%, transparent);
+  border-left: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 70%, transparent);
 }
 
 .feature-grid .bm-chipset kbd.hot {
@@ -533,7 +610,7 @@ main:has(.betamax-hero) {
   font-weight: 700;
 }
 
-:root[data-theme='light'] .feature-grid p {
+:root[data-theme="light"] .feature-grid p {
   color: #4d3c31;
 }
 
@@ -542,7 +619,7 @@ main:has(.betamax-hero) {
 }
 
 .sl-markdown-content:has(.betamax-hero) > h2::after {
-  content: '';
+  content: "";
   display: block;
   width: 2.8rem;
   height: 0.12rem;
@@ -558,7 +635,8 @@ main:has(.betamax-hero) {
   margin: 1rem 0 2.5rem;
   padding: clamp(1.5rem, 4vw, 2.5rem);
   padding-bottom: 8rem;
-  border: 1px solid color-mix(in srgb, var(--sl-color-hairline) 76%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 76%, transparent);
   border-radius: 8px;
   background:
     linear-gradient(135deg, rgba(241, 194, 139, 0.08), transparent 34%),
@@ -568,11 +646,12 @@ main:has(.betamax-hero) {
 /* Curved stripe motif: wraps from top-right, around the corner, and runs
    along the bottom fading out to the left. Sits behind the link text. */
 .next-panel::after {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   z-index: 0;
-  background: url('/betamax/assets/betamax-corner-stripes.svg') right bottom / auto 100% no-repeat;
+  background: url("/betamax/assets/betamax-corner-stripes.svg") right bottom /
+    auto 100% no-repeat;
   -webkit-mask-image: linear-gradient(to right, transparent 2%, #000 50%);
   mask-image: linear-gradient(to right, transparent 2%, #000 50%);
   opacity: 0.95;
@@ -588,13 +667,14 @@ main:has(.betamax-hero) {
   align-items: baseline;
   max-width: calc(100% - 13rem);
   padding: 0.6rem 0;
-  border-top: 1px solid color-mix(in srgb, var(--sl-color-hairline) 34%, transparent);
+  border-top: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 34%, transparent);
   color: inherit;
   text-decoration: none;
 }
 
 .next-panel a::before {
-  content: '→';
+  content: "→";
   color: var(--sl-color-accent);
 }
 
@@ -650,29 +730,30 @@ main:has(.betamax-hero) {
    ============================================================ */
 
 /* --- Warmer ambient glow across the page --- */
-:root:not([data-theme='light']) .page {
+:root:not([data-theme="light"]) .page {
   background:
-    radial-gradient(circle at 18% 12%, rgba(215, 91, 38, 0.075), transparent 820px),
-    radial-gradient(circle at 72% 4%, rgba(196, 176, 136, 0.055), transparent 700px);
-}
-
-:root:not([data-theme='light']) main:has(.betamax-hero) {
-  background:
-    radial-gradient(circle at 70% 20%, rgba(224, 109, 41, 0.22), transparent 26rem),
-    radial-gradient(circle at 20% 12%, rgba(176, 64, 30, 0.12), transparent 22rem),
-    linear-gradient(180deg, #0c0a08 0%, #120e0a 44%, #0b0806 100%);
+    radial-gradient(
+      circle at 18% 12%,
+      rgba(215, 91, 38, 0.075),
+      transparent 820px
+    ),
+    radial-gradient(
+      circle at 72% 4%,
+      rgba(196, 176, 136, 0.055),
+      transparent 700px
+    );
 }
 
 /* --- Top nav: full-width bar --- */
-:root:not([data-theme='light']) .header > .header {
+:root:not([data-theme="light"]) .header > .header {
   padding-inline: 0.5rem;
 }
 
 /* divider + spacing before the theme control */
-:root:not([data-theme='light']) starlight-theme-select {
+:root:not([data-theme="light"]) starlight-theme-select {
   margin-inline-start: 0.85rem;
   padding-inline-start: 0.95rem;
-  border-inline-start: 1px solid color-mix(in srgb, var(--sl-color-hairline) 60%, transparent);
+  border-inline-start: 0;
 }
 
 .feature-grid section {
@@ -686,7 +767,7 @@ main:has(.betamax-hero) .pagination-links {
 }
 
 main:has(.betamax-hero) footer:has(.pagination-links),
-main:has(.betamax-hero) .meta:has(a[href*='edit']) {
+main:has(.betamax-hero) .meta:has(a[href*="edit"]) {
   display: none;
 }
 
@@ -699,7 +780,8 @@ main:has(.betamax-hero) .meta:has(a[href*='edit']) {
   justify-content: space-between;
   margin: 2.5rem 0 1rem;
   padding-top: 1.25rem;
-  border-top: 1px solid color-mix(in srgb, var(--sl-color-hairline) 40%, transparent);
+  border-top: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 40%, transparent);
   color: var(--sl-color-gray-3);
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
   font-size: 0.84rem;
@@ -722,7 +804,1158 @@ main:has(.betamax-hero) .meta:has(a[href*='edit']) {
 }
 
 .betamax-footer-links a + a::before {
-  content: '•';
+  content: "•";
   margin-inline-end: 0.55rem;
   color: var(--sl-color-gray-4);
+}
+
+/* ============================================================
+   Internal docs manual system
+   ============================================================ */
+
+:root {
+  --bm-stripe-cream: #e6c997;
+  --bm-stripe-gold: #d48614;
+  --bm-stripe-orange: #bd471d;
+  --bm-stripe-red: #7f2118;
+  --bm-manual-bg: #060403;
+  --bm-manual-rule: color-mix(
+    in srgb,
+    var(--sl-color-hairline) 62%,
+    transparent
+  );
+  --bm-manual-rule-soft: color-mix(
+    in srgb,
+    var(--sl-color-hairline) 34%,
+    transparent
+  );
+  --bm-manual-text: #ead4b3;
+  --bm-manual-muted: #b99066;
+  --bm-manual-label: #f0782c;
+  --bm-display:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --bm-mono:
+    ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+}
+
+body:not(:has(.betamax-hero)) {
+  --sl-nav-height: 4.5rem;
+}
+
+@media (min-width: 72rem) {
+  body:not(:has(.betamax-hero)) {
+    --sl-sidebar-width: 20.375rem;
+    --sl-content-inline-start: 20.375rem;
+  }
+}
+
+:root:not([data-theme="light"]) {
+  --ec-brdRad: 6px;
+  --ec-brdCol: var(--bm-manual-rule);
+  --ec-codeBg: #090706;
+  --ec-codeFg: #f3dfbd;
+  --ec-codeLineHt: 1.62;
+  --ec-codePadBlk: 1rem;
+  --ec-codePadInl: 1rem;
+  --ec-frm-edBg: #090706;
+  --ec-frm-trmBg: #090706;
+  --ec-frm-trmTtbBg: #150e0a;
+  --ec-frm-trmTtbFg: var(--bm-manual-muted);
+  --ec-frm-trmTtbBrdBtmCol: var(--bm-manual-rule-soft);
+  --ec-frm-trmTtbDotsFg: #7b4d2e;
+  --ec-frm-inlBtnFg: var(--bm-manual-text);
+  --ec-frm-inlBtnBrd: var(--bm-manual-rule);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  pointer-events: none;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 160 160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.82' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='.62'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+}
+
+:root:not([data-theme="light"]) body:not(:has(.betamax-hero)) .page {
+  background:
+    radial-gradient(
+      circle at 15% 9%,
+      rgba(224, 90, 36, 0.1),
+      transparent 48rem
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(214, 167, 102, 0.06),
+      transparent 42rem
+    ),
+    linear-gradient(180deg, #0f0a07 0%, #120d09 36%, var(--bm-manual-bg) 100%);
+}
+
+:root:not([data-theme="light"]) body:not(:has(.betamax-hero)) .page > .header {
+  border-bottom: 0;
+  background: #070504;
+  box-shadow: 0 0.4rem 1.4rem rgba(0, 0, 0, 0.18);
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .header
+  > .header {
+  padding-block: 0.42rem;
+}
+
+:root:not([data-theme="light"]) body:not(:has(.betamax-hero)) .site-title {
+  display: block;
+  flex: none;
+  width: 11.9rem;
+  height: 3.25rem;
+  overflow: hidden;
+  color: #f4e2c2;
+  font-size: 0;
+  text-indent: -999rem;
+  background: url("/betamax/assets/betamax-logo-lockup.png") left center /
+    contain no-repeat;
+  text-shadow: 0 0 1rem rgba(224, 90, 36, 0.16);
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .site-title::before {
+  content: none;
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .header
+  site-search {
+  margin-inline-start: auto;
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .header
+  site-search
+  button {
+  margin-inline-start: auto;
+  min-height: 2.55rem;
+  border: 1px solid var(--bm-manual-rule);
+  border-radius: 6px;
+  color: var(--bm-manual-text);
+  background:
+    linear-gradient(180deg, rgba(23, 15, 10, 0.9), rgba(8, 6, 5, 0.92)),
+    var(--bm-manual-bg);
+  box-shadow:
+    inset 0 1px rgba(255, 225, 185, 0.05),
+    0 0.6rem 1.4rem rgba(0, 0, 0, 0.18);
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .header
+  site-search
+  button
+  > span {
+  color: rgba(205, 177, 132, 0.64);
+}
+
+:root:not([data-theme="light"])
+  body:not(:has(.betamax-hero))
+  .header
+  site-search
+  kbd {
+  border-color: var(--bm-manual-rule);
+  border-radius: 3px;
+  color: var(--bm-manual-muted);
+  background: #17100c;
+}
+
+:root:not([data-theme="light"]) .sidebar-pane {
+  border-right-color: var(--bm-manual-rule);
+  background:
+    linear-gradient(180deg, rgba(13, 9, 6, 0.98), rgba(7, 5, 4, 0.98)), #070504;
+  box-shadow: inset -1px 0 rgba(255, 217, 170, 0.04);
+}
+
+:root:not([data-theme="light"]) .sidebar-content {
+  padding-block: 1rem 1.5rem;
+}
+
+:root:not([data-theme="light"]) .sidebar-pane details {
+  margin-inline: 0.85rem;
+  padding-block: 0.25rem 0.85rem;
+  border-top: 1px solid var(--bm-manual-rule-soft);
+}
+
+:root:not([data-theme="light"]) .sidebar-pane details:first-of-type {
+  border-top: 0;
+}
+
+:root:not([data-theme="light"]) .sidebar-pane summary {
+  color: var(--bm-manual-label);
+  font-family: var(--bm-mono);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+:root:not([data-theme="light"]) .sidebar-pane a {
+  position: relative;
+  padding: 0.36rem 0.5rem 0.36rem 0.75rem;
+  border-radius: 0;
+  color: var(--bm-manual-text);
+  text-decoration: none;
+  background: transparent;
+}
+
+:root:not([data-theme="light"]) .sidebar-pane a:hover {
+  color: #fff0cf;
+  background: rgba(224, 90, 36, 0.08);
+}
+
+:root:not([data-theme="light"]) .sidebar-pane [aria-current="page"] {
+  color: #fff0cf;
+  background: #3a2112;
+  box-shadow:
+    inset 0 1px rgba(255, 227, 190, 0.08),
+    inset 0 -1px rgba(0, 0, 0, 0.22);
+}
+
+:root:not([data-theme="light"]) .sidebar-pane [aria-current="page"]::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: -0.5rem;
+  width: 3px;
+  background: var(--bm-manual-label);
+}
+
+:root:not([data-theme="light"]) .sidebar-pane [aria-current="page"]::after {
+  content: none;
+}
+
+:root:not([data-theme="light"]) .main-pane {
+  background:
+    radial-gradient(
+      circle at 22% 5%,
+      rgba(224, 90, 36, 0.05),
+      transparent 30rem
+    ),
+    linear-gradient(180deg, rgba(13, 9, 7, 0.82), rgba(8, 6, 5, 0.72));
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  > .content-panel:first-child {
+  border-bottom: 0;
+  background:
+    linear-gradient(180deg, rgba(22, 14, 10, 0.78), rgba(13, 9, 7, 0.62)),
+    var(--bm-manual-bg);
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  > .content-panel:first-child
+  .sl-container {
+  padding-block: clamp(0.8rem, 1.1vw, 1rem) 0.5rem;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  > .content-panel:first-child
+  .sl-container::before {
+  content: "Betamax Manual";
+  display: block;
+  margin-bottom: 0.85rem;
+  color: var(--bm-manual-label);
+  font-family: var(--bm-mono);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+:root:not([data-theme="light"]) main:not(:has(.betamax-hero)) h1 {
+  display: block;
+  width: fit-content;
+  max-width: 72rem;
+  color: #f6e4c4;
+  font-family: var(--bm-display);
+  font-size: clamp(3.45rem, 5vw, 4.75rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0;
+  text-wrap: balance;
+  text-shadow:
+    0 0.16rem 0 #5a4a36,
+    0 0.4rem 1rem rgba(0, 0, 0, 0.5);
+}
+
+:root:not([data-theme="light"]) main:not(:has(.betamax-hero)) h1::after {
+  content: none;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  > .content-panel:first-child
+  .sl-container::after {
+  content: "";
+  display: block;
+  width: min(100%, 72rem);
+  height: 1rem;
+  margin-top: 0.6rem;
+  border-radius: 1px;
+  background: linear-gradient(
+    to bottom,
+    var(--bm-stripe-gold) 0 29%,
+    transparent 29% 39%,
+    var(--bm-stripe-orange) 39% 68%,
+    transparent 68% 78%,
+    var(--bm-stripe-red) 78% 100%
+  );
+  box-shadow:
+    0 0.12rem 0 rgba(0, 0, 0, 0.5),
+    0 0.55rem 1.2rem rgba(224, 90, 36, 0.08);
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  > .content-panel
+  + .content-panel {
+  background:
+    linear-gradient(90deg, rgba(214, 167, 102, 0.025), transparent 16rem),
+    transparent;
+  border-top: 0;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content {
+  color: var(--bm-manual-text);
+  font-family: var(--bm-mono);
+  font-size: 0.94rem;
+  line-height: 1.68;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  > p:first-child {
+  color: #f1dfbd;
+  font-size: 1.06rem;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  a {
+  color: #f2a05f;
+  text-decoration-color: rgba(242, 160, 95, 0.62);
+  text-underline-offset: 0.2em;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  a:hover {
+  color: #ffd6a4;
+  text-decoration-color: currentColor;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  > h2 {
+  position: relative;
+  margin-top: clamp(2.75rem, 5vw, 4rem);
+  padding-top: 1.35rem;
+  border-top: 1px solid var(--bm-manual-rule-soft);
+  color: #f4e2c2;
+  font-size: clamp(1.8rem, 3vw, 2.28rem);
+  line-height: 1.12;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  > h2::before {
+  content: "";
+  display: block;
+  width: 4rem;
+  height: 0.36rem;
+  margin-bottom: 0.85rem;
+  border-radius: 2px;
+  background: linear-gradient(
+    to bottom,
+    var(--bm-stripe-cream) 0 22%,
+    transparent 22% 30%,
+    var(--bm-stripe-gold) 30% 47%,
+    transparent 47% 56%,
+    var(--bm-stripe-orange) 56% 74%,
+    transparent 74% 82%,
+    var(--bm-stripe-red) 82% 100%
+  );
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  > h3 {
+  padding-inline-start: 0.9rem;
+  border-inline-start: 3px solid var(--bm-stripe-orange);
+  color: #f1dfbd;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  li::marker {
+  color: var(--bm-manual-label);
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .sl-markdown-content
+  :not(pre)
+  > code {
+  border: 1px solid
+    color-mix(in srgb, var(--sl-color-hairline) 56%, transparent);
+  border-radius: 3px;
+  color: #f5d3a2;
+  background: rgba(58, 38, 25, 0.76);
+}
+
+:root:not([data-theme="light"]) main:not(:has(.betamax-hero)) .expressive-code {
+  margin-block: 1.2rem 1.5rem;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  .frame {
+  border-radius: 6px;
+  box-shadow:
+    0 0.9rem 2rem rgba(0, 0, 0, 0.24),
+    inset 0 1px rgba(255, 226, 190, 0.04);
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  .frame.is-terminal
+  .header {
+  min-height: 2.05rem;
+  justify-content: flex-end;
+  border-color: var(--bm-manual-rule);
+  color: var(--bm-manual-muted);
+  font-family: var(--bm-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  .frame.is-terminal
+  .header
+  .title:empty::before {
+  content: "Command";
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  .frame.is-terminal:has(pre[data-language="sh"])
+  .header
+  .title:empty::before {
+  content: "Shell";
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  .frame.is-terminal:has(pre[data-language="text"])
+  .header
+  .title:empty::before {
+  content: "Tape";
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  pre {
+  border-color: var(--bm-manual-rule);
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  .expressive-code
+  pre
+  > code {
+  font-size: 0.9rem;
+}
+
+:root:not([data-theme="light"]) main:not(:has(.betamax-hero)) table {
+  overflow: hidden;
+  width: 100%;
+  border: 1px solid var(--bm-manual-rule);
+  border-radius: 6px;
+  background: rgba(10, 7, 5, 0.56);
+  box-shadow: 0 0.7rem 1.8rem rgba(0, 0, 0, 0.18);
+}
+
+:root:not([data-theme="light"]) main:not(:has(.betamax-hero)) table th {
+  color: #f3d6a8;
+  font-family: var(--bm-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  background: #17100c;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  table
+  :is(th, td) {
+  border-color: var(--bm-manual-rule-soft);
+  padding: 0.78rem 0.9rem;
+}
+
+:root:not([data-theme="light"])
+  main:not(:has(.betamax-hero))
+  table
+  tr:nth-child(even)
+  td {
+  background: rgba(214, 167, 102, 0.025);
+}
+
+:root:not([data-theme="light"]) main:not(:has(.betamax-hero)) blockquote {
+  border-inline-start: 3px solid var(--bm-stripe-orange);
+  border-radius: 0 6px 6px 0;
+  color: var(--bm-manual-text);
+  background: rgba(47, 30, 20, 0.42);
+}
+
+:root:not([data-theme="light"]) .main-pane:has(.bm-quickstart) {
+  --sl-content-width: 74rem;
+}
+
+:root:not([data-theme="light"])
+  .lg\:sl-flex:has(> .main-pane .bm-quickstart)
+  > .right-sidebar-container {
+  display: none;
+}
+
+:root:not([data-theme="light"])
+  .lg\:sl-flex:has(> .main-pane .bm-quickstart)
+  > .main-pane {
+  width: 100%;
+}
+
+:root:not([data-theme="light"])
+  main:has(.bm-quickstart)
+  > .content-panel:first-child
+  .sl-container::before {
+  content: "Start / Quick Start";
+}
+
+:root:not([data-theme="light"]) .main-pane:has(.bm-manual-page) {
+  --sl-content-width: 74rem;
+}
+
+@media (min-width: 50.001rem) {
+  :root:not([data-theme="light"])
+    main:has(.bm-manual-page)
+    > .content-panel:first-child {
+    border-bottom-color: transparent;
+  }
+
+  :root:not([data-theme="light"])
+    main:has(.bm-manual-page)
+    > .content-panel
+    + .content-panel {
+    margin-top: -1.85rem;
+  }
+
+  :root:not([data-theme="light"])
+    main:has(.bm-manual-page)
+    > .content-panel
+    + .content-panel
+    .sl-container {
+    padding-top: 0;
+  }
+}
+
+:root:not([data-theme="light"])
+  .lg\:sl-flex:has(> .main-pane .bm-manual-page)
+  > .right-sidebar-container {
+  display: none;
+}
+
+:root:not([data-theme="light"])
+  .lg\:sl-flex:has(> .main-pane .bm-manual-page)
+  > .main-pane {
+  width: 100%;
+}
+
+:root:not([data-theme="light"])
+  main:has(.bm-tape-files)
+  > .content-panel:first-child
+  .sl-container::before {
+  content: "Authoring / Tape Files";
+}
+
+.bm-manual-page {
+  --ec-codeLineHt: 1.38;
+  --ec-codePadBlk: 0.66rem;
+  --ec-codePadInl: 0.82rem;
+}
+
+:root:not([data-theme="light"]) .bm-manual-page {
+  color: var(--bm-manual-text);
+}
+
+.bm-manual-lede {
+  max-width: 42rem;
+  margin: 0 0 1rem;
+  font-size: 0.84rem;
+  line-height: 1.52;
+}
+
+:root:not([data-theme="light"]) .bm-manual-lede {
+  color: #e6d0ad;
+}
+
+.bm-manual-row {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.76fr) minmax(22rem, 1fr) minmax(
+      14rem,
+      0.64fr
+    );
+  gap: clamp(1.3rem, 2.3vw, 2rem);
+  align-items: start;
+  margin: 0;
+  padding: 0.5rem 0 1rem;
+}
+
+:root:not([data-theme="light"]) .bm-manual-row {
+  border-top: 1px solid var(--bm-manual-rule-soft);
+}
+
+.bm-manual-row-top {
+  padding-top: 0.5rem;
+}
+
+:root:not([data-theme="light"]) .bm-manual-row:first-of-type {
+  border-top: 0;
+}
+
+.bm-manual-row + .bm-manual-row {
+  padding-top: 1rem;
+}
+
+.bm-manual-copy {
+  min-width: 0;
+}
+
+.bm-manual-row > * {
+  margin-block: 0;
+}
+
+.bm-manual-copy > :first-child {
+  margin-top: 0;
+}
+
+.bm-manual-copy > :last-child {
+  margin-bottom: 0;
+}
+
+.bm-manual-copy > .sl-heading-wrapper {
+  position: relative;
+  margin: 0 0 0.55rem;
+  line-height: 1;
+}
+
+.bm-manual-copy > .sl-heading-wrapper > h2,
+.bm-manual-copy > h2 {
+  margin: 0 0 0.72rem;
+  color: #f4e2c2;
+  font-family: var(--bm-display);
+  font-size: clamp(1.12rem, 1.6vw, 1.38rem);
+  font-weight: 800;
+  line-height: 1.12;
+  letter-spacing: 0;
+  overflow-wrap: normal;
+  text-wrap: balance;
+}
+
+.bm-manual-copy > .sl-heading-wrapper > h2 {
+  display: inline-block;
+  margin: 0;
+  vertical-align: top;
+}
+
+.bm-manual-copy > .sl-heading-wrapper > .sl-anchor-link {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: calc(100% + 0.25rem);
+}
+
+.bm-manual-copy :is(p, li) {
+  font-size: 0.78rem;
+  line-height: 1.46;
+}
+
+.bm-manual-copy ul,
+.bm-manual-copy ol {
+  margin-block: 0.45rem 0;
+  padding-inline-start: 1.25rem;
+}
+
+.bm-manual-code {
+  min-width: 0;
+}
+
+.bm-manual-code .expressive-code,
+.bm-manual-code .expressive-code .frame,
+.bm-manual-code .expressive-code pre {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+:root:not([data-theme="light"]) .bm-manual-code .expressive-code {
+  margin-block: 0 !important;
+}
+
+:root:not([data-theme="light"]) .bm-manual-code .expressive-code .frame {
+  overflow: hidden;
+  border: 1px solid var(--bm-manual-rule);
+  border-radius: 6px;
+  background: rgba(8, 6, 5, 0.76);
+  box-shadow: none;
+}
+
+:root:not([data-theme="light"])
+  .bm-manual-code
+  .expressive-code
+  .frame.is-terminal
+  .header {
+  display: none;
+}
+
+:root:not([data-theme="light"]) .bm-manual-code .expressive-code pre {
+  border: 0;
+  background:
+    linear-gradient(180deg, rgba(214, 167, 102, 0.035), transparent 44%),
+    #090706;
+}
+
+:root:not([data-theme="light"]) .bm-manual-code .expressive-code pre > code {
+  color: #f3dfbd;
+  font-size: 0.76rem !important;
+  line-height: 1.38 !important;
+}
+
+.bm-compact-code .expressive-code pre > code {
+  font-size: 0.74rem !important;
+}
+
+.bm-manual-note {
+  min-width: 0;
+  margin: 0;
+  padding: 0.82rem 0.9rem;
+  border-radius: 6px;
+}
+
+:root:not([data-theme="light"]) .bm-manual-note {
+  border: 1px solid var(--bm-manual-rule);
+  color: var(--bm-manual-text);
+  background:
+    linear-gradient(135deg, rgba(224, 90, 36, 0.075), transparent 42%),
+    rgba(12, 8, 6, 0.62);
+}
+
+.bm-manual-note > :first-child {
+  margin-top: 0;
+}
+
+.bm-manual-note > :last-child {
+  margin-bottom: 0;
+}
+
+.bm-manual-note p,
+.bm-manual-note li {
+  font-size: 0.74rem;
+  line-height: 1.48;
+}
+
+.bm-manual-note ul {
+  padding-inline-start: 1rem;
+}
+
+:root:not([data-theme="light"]) .bm-manual-note .bm-note-label {
+  margin-bottom: 0.55rem;
+  color: var(--bm-manual-label);
+  font-size: 0.7rem;
+  text-transform: none;
+}
+
+.bm-quickstart {
+  counter-reset: bm-step;
+  --ec-codeLineHt: 1.54;
+  --ec-codePadBlk: 0.74rem;
+}
+
+:root:not([data-theme="light"]) .bm-guide-lede {
+  max-width: 48rem;
+  margin: 0 0 1.35rem;
+  color: #f1dfbd;
+  font-size: 1.02rem;
+  line-height: 1.68;
+}
+
+.bm-step-index {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  margin: 1.25rem 0 1.7rem;
+  border-radius: 6px;
+}
+
+:root:not([data-theme="light"]) .bm-step-index {
+  border: 1px solid var(--bm-manual-rule);
+  background: rgba(12, 8, 6, 0.72);
+}
+
+.bm-step-index a {
+  display: grid;
+  min-width: 0;
+  gap: 0.25rem;
+  padding: 0.82rem 0.85rem 0.78rem;
+  text-decoration: none;
+}
+
+:root:not([data-theme="light"]) .bm-step-index a {
+  color: var(--bm-manual-text);
+  background:
+    linear-gradient(180deg, rgba(214, 167, 102, 0.035), transparent 60%),
+    rgba(13, 9, 7, 0.48);
+}
+
+:root:not([data-theme="light"]) .bm-step-index a + a {
+  border-inline-start: 1px solid var(--bm-manual-rule-soft);
+}
+
+:root:not([data-theme="light"]) .bm-step-index a:hover {
+  color: #fff0cf;
+  background: rgba(224, 90, 36, 0.1);
+}
+
+.bm-step-index span,
+.bm-step-index small {
+  font-family: var(--bm-mono);
+}
+
+:root:not([data-theme="light"]) .bm-step-index span {
+  color: var(--bm-manual-label);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.bm-step-index strong {
+  overflow-wrap: anywhere;
+  font-size: 0.9rem;
+  line-height: 1.16;
+}
+
+:root:not([data-theme="light"]) .bm-step-index small {
+  color: var(--bm-manual-muted);
+  font-size: 0.7rem;
+  line-height: 1.25;
+}
+
+.bm-step {
+  counter-increment: bm-step;
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.78fr) minmax(20rem, 1fr);
+  gap: clamp(1.4rem, 3.8vw, 2.7rem);
+  align-items: start;
+  margin: 0;
+  padding: clamp(1.45rem, 3vw, 2rem) 0;
+}
+
+:root:not([data-theme="light"]) .bm-step {
+  border-top: 1px solid var(--bm-manual-rule-soft);
+}
+
+.bm-step:first-of-type {
+  padding-top: 1.25rem;
+}
+
+.bm-step-copy > h2 {
+  display: flex;
+  gap: 0.72rem;
+  align-items: baseline;
+  margin: 0 0 0.9rem;
+  font-size: clamp(1.55rem, 2.4vw, 2rem);
+  line-height: 1.14;
+}
+
+:root:not([data-theme="light"]) .bm-step-copy > h2 {
+  color: #f4e2c2;
+}
+
+.bm-step-copy > h2::before {
+  content: counter(bm-step, decimal-leading-zero);
+  flex: none;
+  font-family: var(--bm-mono);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+:root:not([data-theme="light"]) .bm-step-copy > h2::before {
+  color: var(--bm-manual-label);
+}
+
+.bm-step-copy > h2::after {
+  content: "";
+  flex: 1 1 auto;
+  min-width: 2rem;
+  height: 0.2rem;
+  border-radius: 2px;
+}
+
+:root:not([data-theme="light"]) .bm-step-copy > h2::after {
+  background: linear-gradient(
+    to bottom,
+    var(--bm-stripe-cream) 0 22%,
+    transparent 22% 30%,
+    var(--bm-stripe-gold) 30% 47%,
+    transparent 47% 56%,
+    var(--bm-stripe-orange) 56% 74%,
+    transparent 74% 82%,
+    var(--bm-stripe-red) 82% 100%
+  );
+  opacity: 0.82;
+}
+
+.bm-step-copy > :first-child {
+  margin-top: 0;
+}
+
+.bm-step-copy > :last-child {
+  margin-bottom: 0;
+}
+
+.bm-step-action {
+  display: grid;
+  gap: 0.85rem;
+  align-content: start;
+  min-width: 0;
+}
+
+:root:not([data-theme="light"]) .bm-step-action .expressive-code {
+  margin-block: 0;
+}
+
+.bm-quickstart .expressive-code,
+.bm-quickstart .expressive-code .frame,
+.bm-quickstart .expressive-code pre {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+:root:not([data-theme="light"]) .bm-quickstart .expressive-code {
+  margin-block: 0.82rem 1.05rem;
+}
+
+:root:not([data-theme="light"])
+  .bm-quickstart
+  .expressive-code
+  .frame.is-terminal
+  .header {
+  min-height: 1.66rem;
+  padding-block: 0.12rem;
+  background: #130d09;
+}
+
+:root:not([data-theme="light"]) .bm-quickstart .expressive-code pre > code {
+  font-size: 0.86rem;
+}
+
+.bm-step-note {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0;
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+:root:not([data-theme="light"]) .bm-step-note {
+  border: 1px solid var(--bm-manual-rule);
+  color: var(--bm-manual-text);
+  background:
+    linear-gradient(135deg, rgba(224, 90, 36, 0.08), transparent 44%),
+    rgba(12, 8, 6, 0.62);
+}
+
+.bm-step-note p {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.52;
+}
+
+.bm-step-note p + p {
+  padding-top: 0.75rem;
+}
+
+:root:not([data-theme="light"]) .bm-step-note p + p {
+  border-top: 1px solid var(--bm-manual-rule-soft);
+}
+
+.bm-note-label {
+  display: inline-flex;
+  gap: 0.48rem;
+  align-items: center;
+  font-family: var(--bm-mono);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+:root:not([data-theme="light"]) .bm-note-label {
+  color: var(--bm-manual-label);
+}
+
+.bm-note-label::before {
+  content: "i";
+  display: inline-grid;
+  place-items: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  font-family: var(--bm-mono);
+  font-size: 0.68rem;
+  line-height: 1;
+}
+
+:root:not([data-theme="light"]) .bm-note-label::before {
+  border: 1px solid var(--bm-manual-label);
+  color: var(--bm-manual-label);
+}
+
+:root:not([data-theme="light"]) .right-sidebar {
+  border-left-color: var(--bm-manual-rule);
+  background:
+    linear-gradient(180deg, rgba(17, 11, 8, 0.86), rgba(8, 6, 5, 0.78)),
+    transparent;
+}
+
+:root:not([data-theme="light"]) .right-sidebar starlight-toc {
+  display: block;
+  margin: 1rem 1rem 0;
+  padding: 0.9rem 0.85rem;
+  border: 1px solid var(--bm-manual-rule-soft);
+  border-radius: 6px;
+  background: rgba(12, 8, 6, 0.64);
+}
+
+:root:not([data-theme="light"]) .right-sidebar h2 {
+  color: #f4e2c2;
+  font-size: 0.92rem;
+}
+
+:root:not([data-theme="light"]) .right-sidebar a {
+  border-inline-start: 2px solid transparent;
+  color: var(--bm-manual-muted);
+  text-decoration: none;
+}
+
+:root:not([data-theme="light"]) .right-sidebar a:hover,
+:root:not([data-theme="light"]) .right-sidebar a[aria-current="true"] {
+  border-inline-start-color: var(--bm-stripe-orange);
+  color: #ffd6a4;
+}
+
+@media (max-width: 82rem) {
+  .bm-manual-row {
+    grid-template-columns: minmax(16rem, 0.8fr) minmax(20rem, 1fr);
+  }
+
+  .bm-manual-note {
+    grid-column: 2;
+  }
+
+  .bm-step-index {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .bm-step-index a:nth-child(4) {
+    border-inline-start: 0;
+  }
+
+  .bm-step {
+    grid-template-columns: 1fr;
+  }
+
+  :root:not([data-theme="light"]) .right-sidebar starlight-toc {
+    margin-inline: 0;
+  }
+}
+
+@media (max-width: 50rem) {
+  .bm-manual-row {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    padding-block: 1.25rem;
+  }
+
+  .bm-manual-note {
+    grid-column: auto;
+  }
+
+  .bm-manual-lede {
+    font-size: 0.9rem;
+  }
+
+  :root:not([data-theme="light"]) .bm-manual-code .expressive-code pre > code {
+    font-size: 0.78rem;
+  }
+
+  .bm-manual-code .expressive-code pre,
+  .bm-manual-code .expressive-code pre > code {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .bm-compact-code .expressive-code pre > code {
+    font-size: 0.76rem;
+  }
+
+  .bm-step-index {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bm-step-index a:nth-child(odd) {
+    border-inline-start: 0;
+  }
+
+  :root:not([data-theme="light"])
+    main:not(:has(.betamax-hero))
+    > .content-panel:first-child
+    .sl-container {
+    padding-block-start: 2rem;
+  }
+
+  :root:not([data-theme="light"]) main:not(:has(.betamax-hero)) h1 {
+    font-size: clamp(2.25rem, 12vw, 3.25rem);
+  }
 }


### PR DESCRIPTION
## Summary

- Add a DESIGN.md contract for the Betamax docs interior design language.
- Restyle internal docs pages toward the warm manual direction while keeping the homepage scoped separately.
- Rework Quick Start and Tape Files layouts for procedural/manual-style sections.

## Validation

- `pnpm docs:check`
- `pnpm docs:build`
- Browser checked Tape Files scroll behavior at 0px and 80px; header/sidebar stay fixed, content scrolls, horizontal overflow is 0.
- Verified the pushed commit changes only text docs/CSS paths and does not include the LFS-tracked homepage assets.

## Notes

The docs build still emits the existing runtime asset warnings for `/betamax/assets/...`; the build completes successfully.
