### PR TITLE
Instrument release Ubuntu smoke crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,12 @@ jobs:
       - name: Cache Rust builds
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Install Ubuntu crash diagnostics
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb binutils
+
       - name: Package crates
         run: mise run package
 
@@ -159,7 +165,43 @@ jobs:
         run: mise run install-smoke
 
       - name: Render smoke tape
-        run: mise run smoke
+        env:
+          RUST_BACKTRACE: full
+        run: |
+          set -uo pipefail
+          mise run smoke
+          status=$?
+          if [[ "$status" -eq 0 ]]; then
+            exit 0
+          fi
+          if [[ "${{ matrix.os }}" != "ubuntu-latest" ]]; then
+            exit "$status"
+          fi
+
+          echo "::group::Ubuntu CPU and binary diagnostics"
+          uname -a || true
+          lscpu || true
+          grep -m1 '^flags' /proc/cpuinfo || true
+          file target/debug/betamax || true
+          ldd target/debug/betamax || true
+          echo "::endgroup::"
+
+          cargo build -p betamax
+          gdb -q -batch \
+            -ex 'set pagination off' \
+            -ex 'set confirm off' \
+            -ex 'run run examples/basic.tape' \
+            -ex 'printf "\n--- program ---\n"' \
+            -ex 'info program' \
+            -ex 'printf "\n--- registers ---\n"' \
+            -ex 'info registers' \
+            -ex 'printf "\n--- disassembly around pc ---\n"' \
+            -ex 'x/24i $pc-32' \
+            -ex 'printf "\n--- all threads ---\n"' \
+            -ex 'thread apply all bt full' \
+            --args target/debug/betamax || true
+
+          exit "$status"
 
   dependencies:
     name: Dependency check (${{ matrix.name }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
+## [0.1.9](https://github.com/joshka/betamax/compare/betamax-v0.1.8...betamax-v0.1.9) - 2026-06-16
+
+### Other
+
+- Use static libghostty-vt builds ([#66](https://github.com/joshka/betamax/pull/66))
+- Add homepage quick-start demo ([#60](https://github.com/joshka/betamax/pull/60))
+
+## [0.1.5](https://github.com/joshka/betamax/compare/betamax-core-v0.1.4...betamax-core-v0.1.5) - 2026-06-16
+
+### Other
+
+- Use static libghostty-vt builds ([#66](https://github.com/joshka/betamax/pull/66))
+
 ## [0.1.8](https://github.com/joshka/betamax/compare/betamax-v0.1.7...betamax-v0.1.8) - 2026-06-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "betamax"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "betamax-core",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "betamax-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cosmic-text",
  "gif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["crates/betamax"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ documentation = "https://www.joshka.net/betamax/"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-betamax-core = { path = "crates/betamax-core", version = "0.1.4" }
+betamax-core = { path = "crates/betamax-core", version = "0.1.5" }
 clap = { version = "4.5.20", features = ["derive", "wrap_help"] }
 clap-stdin = "0.8"
 cosmic-text = "0.19"

--- a/crates/betamax/Cargo.toml
+++ b/crates/betamax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "betamax"
 description = "Rust-first VHS-style terminal capture CLI"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
Diagnostic branch for the Ubuntu SIGILL seen on release-plz PR #59.

This intentionally starts from the PR #59 release commit, but uses a separate `joshka/` branch so the release-plz branch stays unchanged.

The CI change only adds Ubuntu crash diagnostics around `mise run smoke`; it exits with the original smoke status and only prints gdb/CPU/binary details after a failure.
