### PR TITLE
Use libghostty tracing logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,6 @@ dependencies = [
  "glob",
  "interpolator",
  "libghostty-vt",
- "log",
  "miette",
  "serde_json",
  "tracing",
@@ -541,20 +540,18 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libghostty-vt"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c77176dd05b2b5718046d807e786473f463ea6d478d56f8c0105e2fe6f71f5"
+source = "git+https://github.com/Uzaaft/libghostty-rs?rev=f6cc545dcbe2db319cdb1a28ef24b0cdf13301fa#f6cc545dcbe2db319cdb1a28ef24b0cdf13301fa"
 dependencies = [
  "bitflags 2.11.1",
  "int-enum",
  "libghostty-vt-sys",
- "log",
+ "tracing",
 ]
 
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404671567c0ac43389a69ae424eefc89390a25d3a5386a54249cdaf13e01b411"
+source = "git+https://github.com/Uzaaft/libghostty-rs?rev=f6cc545dcbe2db319cdb1a28ef24b0cdf13301fa#f6cc545dcbe2db319cdb1a28ef24b0cdf13301fa"
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ cosmic-text = "0.19"
 gif = "0.14"
 glob = "0.3"
 interpolator = "0.5"
-libghostty-vt = { version = "0.2.0", features = ["log"] }
-log = "0.4.29"
+libghostty-vt = { git = "https://github.com/Uzaaft/libghostty-rs", rev = "f6cc545dcbe2db319cdb1a28ef24b0cdf13301fa", features = ["tracing"] }
 miette = "7"
 png = "0.18"
 portable-pty = "0.9"

--- a/crates/betamax/Cargo.toml
+++ b/crates/betamax/Cargo.toml
@@ -31,7 +31,6 @@ clap-stdin.workspace = true
 glob.workspace = true
 interpolator.workspace = true
 libghostty-vt.workspace = true
-log.workspace = true
 miette = { workspace = true, features = ["fancy"] }
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/betamax/src/main.rs
+++ b/crates/betamax/src/main.rs
@@ -24,7 +24,8 @@ fn main() -> Result<()> {
         .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_writer(std::io::stderr)
         .init();
-    if let Err(error) = libghostty_vt::set_logger(Some(Box::new(log::logger()))) {
+    if let Err(error) = libghostty_vt::set_logger(Some(Box::new(libghostty_vt::log::TracingLogger)))
+    {
         tracing::debug!(%error, "failed to install libghostty-vt logger");
     }
     Cli::run()


### PR DESCRIPTION
## Summary

Route Ghostty messages directly through `libghostty_vt::log::TracingLogger`, so `RUST_LOG` can filter the `libghostty_vt::ghostty` target while retaining the structured `ghostty_scope` field.

Use published `libghostty-vt` 0.2.1 with its `tracing` feature, remove the CLI and workspace direct `log` dependency, and refresh the lockfile. Raise the workspace `tracing` minimum to 0.1.44 because the upstream feature requires it; this also makes direct-minimal-version resolution succeed. The temporary Git dependency and upstream release blocker are gone. Rebased on current `main`.

## Validation

- Formatting, `cargo test --workspace --all-targets --locked` (57 unit tests and 4 integration tests), and `cargo clippy --workspace --all-targets --locked -- -D warnings` pass.
- `mise run minimal-versions` passes with the updated tracing minimum.
- Rendered `examples/basic.tape` successfully with `RUST_LOG='libghostty_vt::ghostty=warn,betamax_core::runner=debug'`.
- A captured tape emitting malformed CSI `ESC[1;2A` produces the expected Ghostty warning with `ghostty_scope="stream"` at `libghostty_vt::ghostty=warn`; changing that target to `error` suppresses it while runner debug events remain enabled in both runs.

Local native builds used pinned Zig 0.15.2 with temporary process-local wrappers selecting the macOS 15.2 SDK, to avoid the separately reproduced system-SDK linker problem. No SDK workaround or global configuration changes are included in this PR. All checks pass on head `1b1c55a5`, including required CI, Linux/macOS tests and package/smoke jobs, minimal versions, dependency policy, lint/docs, and CodeQL.
