### PR TITLE
Fix release-plz release loop

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,7 +17,20 @@ jobs:
     name: Release-plz release
     environment: release
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'joshka' }}
+    # This job publishes crates and therefore enters the protected `release` environment. Keep it
+    # off ordinary `main` pushes so non-release merges do not require release approval.
+    #
+    # release-plz release PRs are merged with squash commits whose subjects are `chore: release` or
+    # the older `chore(<package>): release ...` form. Manual dispatch remains available for repair.
+    if: >-
+      ${{
+        github.repository_owner == 'joshka' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          startsWith(github.event.head_commit.message, 'chore: release') ||
+          contains(github.event.head_commit.message, '): release')
+        )
+      }}
     permissions:
       contents: write
       pull-requests: read
@@ -143,7 +156,18 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'joshka' }}
+    # release-plz's quickstart runs `release` and `release-pr` as sibling jobs on every `main` push.
+    # In this repo the release job publishes via a protected environment and then uploads binary
+    # assets in the same workflow run. If `release-pr` also runs on a release-PR merge, it can read
+    # crates.io before the sibling publish finishes and open a stale PR for the versions being
+    # released. Skip release commits here; the next ordinary merge will refresh the release PR.
+    if: >-
+      ${{
+        github.repository_owner == 'joshka' &&
+        github.event_name == 'push' &&
+        !startsWith(github.event.head_commit.message, 'chore: release') &&
+        !contains(github.event.head_commit.message, '): release')
+      }}
     permissions:
       contents: write
       pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,20 +18,6 @@
 
 ### Other
 
-- release ([#59](https://github.com/joshka/betamax/pull/59))
-- Use static libghostty-vt builds ([#66](https://github.com/joshka/betamax/pull/66))
-- Add homepage quick-start demo ([#60](https://github.com/joshka/betamax/pull/60))
-
-## [0.1.5](https://github.com/joshka/betamax/compare/betamax-core-v0.1.4...betamax-core-v0.1.5) - 2026-06-16
-
-### Other
-
-- Use static libghostty-vt builds ([#66](https://github.com/joshka/betamax/pull/66))
-
-## [0.1.9](https://github.com/joshka/betamax/compare/betamax-v0.1.8...betamax-v0.1.9) - 2026-06-16
-
-### Other
-
 - Use static libghostty-vt builds ([#66](https://github.com/joshka/betamax/pull/66))
 - Add homepage quick-start demo ([#60](https://github.com/joshka/betamax/pull/60))
 


### PR DESCRIPTION
## Summary

This fixes the release-plz loop that produced stale release PRs after release PR merges.

The release-plz quickstart uses two sibling jobs on every `main` push:

- `release-plz release`, which publishes any bumped versions that are not yet on crates.io.
- `release-plz release-pr`, which compares local versions with crates.io and opens or updates the next release PR.

That default shape is fine until this repo adds two repo-specific constraints:

- Publishing enters the protected `release` environment, so every ordinary `main` push was asking for release approval even when there was nothing to publish.
- Binary assets are uploaded from the same workflow run because releases created with the default `GITHUB_TOKEN` do not trigger follow-up release/tag workflows.

On a release PR merge, both sibling jobs started together. The `release-pr` job could query crates.io before the `release` job finished publishing the just-merged versions. That made release-plz think the bumped local versions were still unpublished, so it opened a new release PR for versions that were already in flight. That is what happened with #75 after #73 merged.

## Changes

- Run `release-plz release` only for release squash commits or manual dispatch, so normal merges do not request the protected release environment.
- Skip `release-plz release-pr` on release squash commits, so it cannot race the sibling publish job against crates.io.
- Document the reason for both guards directly in the workflow.
- Remove duplicate `0.1.9` / `0.1.5` changelog sections left by the stale release-plz follow-up.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-plz.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/release-plz.yml`
- `mise run lint-md`
- `release-plz release --dry-run --allow-dirty -o json` in a temporary Git clone returned `{"releases":[]}`
- `mise run release-check`
