### PR TITLE
Add media encoding progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "clap",
  "clap-stdin",
  "glob",
+ "indicatif",
  "interpolator",
  "libghostty-vt",
  "log",
@@ -178,6 +179,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -274,6 +281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys",
+]
+
+[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +469,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +540,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "int-enum"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +587,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -725,6 +798,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-pty"
@@ -976,6 +1055,12 @@ dependencies = [
  "bytemuck",
  "read-fonts",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -1286,6 +1371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1417,61 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "weezl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cosmic-text = "0.19"
 gif = "0.14"
 glob = "0.3"
 interpolator = "0.5"
+indicatif = "0.18.4"
 libghostty-vt = { version = "0.2.0", features = ["log"] }
 log = "0.4.29"
 miette = "7"

--- a/crates/betamax-core/src/media.rs
+++ b/crates/betamax-core/src/media.rs
@@ -42,6 +42,50 @@ const VIDEO_FRAMERATE_PRECISION: usize = 3;
 /// value and keeps WebM output useful without making example assets unnecessarily large.
 const WEBM_CRF: &str = "30";
 
+/// Media writer stage that can report deterministic frame progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaProgressKind {
+    /// Animated GIF frame encoding.
+    Gif,
+    /// Numbered PNG frame sequence writing.
+    PngSequence,
+    /// Temporary PNG frame writing before handing video encoding to `ffmpeg`.
+    VideoFrames,
+}
+
+/// Determinate progress for media writers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MediaProgress {
+    /// Writer stage being reported.
+    pub kind: MediaProgressKind,
+    /// Completed units.
+    pub position: usize,
+    /// Total units expected for this stage.
+    pub total: usize,
+}
+
+/// Receives media progress updates.
+pub trait MediaProgressReporter: Send {
+    /// Report the latest completed frame count for a media-writing stage.
+    fn report(&mut self, progress: MediaProgress);
+}
+
+impl<T> MediaProgressReporter for Box<T>
+where
+    T: MediaProgressReporter + ?Sized,
+{
+    fn report(&mut self, progress: MediaProgress) {
+        self.as_mut().report(progress);
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NoMediaProgress;
+
+impl MediaProgressReporter for NoMediaProgress {
+    fn report(&mut self, _progress: MediaProgress) {}
+}
+
 /// Pixel byte order for a [`Frame`].
 ///
 /// Betamax normalizes both supported formats to tightly packed RGBA when writing image formats.
@@ -179,17 +223,34 @@ pub fn write_png(path: &Path, frame: &Frame) -> Result<()> {
 /// Returns an error if no frames are provided, the output directory cannot be created, or any frame
 /// cannot be written as PNG.
 pub fn write_png_sequence(path: &Path, frames: &[(Frame, Duration)]) -> Result<()> {
+    write_png_sequence_with_progress(path, frames, &mut NoMediaProgress)
+}
+
+/// Write a directory of numbered PNG frames, reporting progress after each frame.
+///
+/// See [`write_png_sequence`] for output behavior and error cases.
+pub fn write_png_sequence_with_progress(
+    path: &Path,
+    frames: &[(Frame, Duration)],
+    progress: &mut impl MediaProgressReporter,
+) -> Result<()> {
     if frames.is_empty() {
         return Err(miette!("cannot write PNG sequence with no frames").into());
     }
     fs::create_dir_all(path)
         .into_diagnostic()
         .map_err(|error| error.wrap_err(format!("failed to create {}", path.display())))?;
+    let total = frames.len();
     for (index, (frame, _)) in frames.iter().enumerate() {
         write_png(
             &path.join(format!("{index:0width$}.png", width = FRAME_INDEX_WIDTH)),
             frame,
         )?;
+        progress.report(MediaProgress {
+            kind: MediaProgressKind::PngSequence,
+            position: index + 1,
+            total,
+        });
     }
     Ok(())
 }
@@ -241,6 +302,17 @@ pub fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
 /// Returns an error if no frames are provided, frame dimensions exceed GIF limits, frames have
 /// inconsistent dimensions, a frame cannot be converted to RGBA, or file creation/encoding fails.
 pub fn write_gif(path: &Path, frames: &[(Frame, Duration)]) -> Result<()> {
+    write_gif_with_progress(path, frames, &mut NoMediaProgress)
+}
+
+/// Write an animated GIF with an infinite loop, reporting progress after each frame.
+///
+/// See [`write_gif`] for output behavior and error cases.
+pub fn write_gif_with_progress(
+    path: &Path,
+    frames: &[(Frame, Duration)],
+    progress: &mut impl MediaProgressReporter,
+) -> Result<()> {
     let Some((first, _)) = frames.first() else {
         return Err(miette!("cannot write GIF with no frames").into());
     };
@@ -255,7 +327,8 @@ pub fn write_gif(path: &Path, frames: &[(Frame, Duration)]) -> Result<()> {
         GifEncoder::new(BufWriter::new(file), width, height, &[]).into_diagnostic()?;
     encoder.set_repeat(Repeat::Infinite).into_diagnostic()?;
 
-    for (frame, delay) in frames {
+    let total = frames.len();
+    for (index, (frame, delay)) in frames.iter().enumerate() {
         if frame.width != first.width || frame.height != first.height {
             return Err(miette!("all GIF frames must have the same dimensions").into());
         }
@@ -264,6 +337,11 @@ pub fn write_gif(path: &Path, frames: &[(Frame, Duration)]) -> Result<()> {
             GifFrame::from_rgba_speed(width, height, &mut rgba, GIF_QUANTIZATION_SPEED);
         gif_frame.delay = gif_delay(*delay);
         encoder.write_frame(&gif_frame).into_diagnostic()?;
+        progress.report(MediaProgress {
+            kind: MediaProgressKind::Gif,
+            position: index + 1,
+            total,
+        });
     }
 
     Ok(())
@@ -282,6 +360,18 @@ pub fn write_mp4(path: &Path, frames: &[(Frame, Duration)], framerate: f64) -> R
     write_video(path, frames, framerate, VideoFormat::Mp4)
 }
 
+/// Write an MP4 video through `ffmpeg`, reporting progress while writing temporary frames.
+///
+/// See [`write_mp4`] for output behavior and error cases.
+pub fn write_mp4_with_progress(
+    path: &Path,
+    frames: &[(Frame, Duration)],
+    framerate: f64,
+    progress: &mut impl MediaProgressReporter,
+) -> Result<()> {
+    write_video_with_progress(path, frames, framerate, VideoFormat::Mp4, progress)
+}
+
 /// Write a WebM video through `ffmpeg`.
 ///
 /// See [`write_mp4`] for the process-backed encoding tradeoff. WebM uses VP9-specific ffmpeg
@@ -293,6 +383,18 @@ pub fn write_mp4(path: &Path, frames: &[(Frame, Duration)], framerate: f64) -> R
 /// exits unsuccessfully, or if cleanup of the temporary frame directory fails after encoding.
 pub fn write_webm(path: &Path, frames: &[(Frame, Duration)], framerate: f64) -> Result<()> {
     write_video(path, frames, framerate, VideoFormat::Webm)
+}
+
+/// Write a WebM video through `ffmpeg`, reporting progress while writing temporary frames.
+///
+/// See [`write_webm`] for output behavior and error cases.
+pub fn write_webm_with_progress(
+    path: &Path,
+    frames: &[(Frame, Duration)],
+    framerate: f64,
+    progress: &mut impl MediaProgressReporter,
+) -> Result<()> {
+    write_video_with_progress(path, frames, framerate, VideoFormat::Webm, progress)
 }
 
 /// Video container and codec preset selected from the requested output extension.
@@ -348,6 +450,16 @@ fn write_video(
     framerate: f64,
     format: VideoFormat,
 ) -> Result<()> {
+    write_video_with_progress(path, frames, framerate, format, &mut NoMediaProgress)
+}
+
+fn write_video_with_progress(
+    path: &Path,
+    frames: &[(Frame, Duration)],
+    framerate: f64,
+    format: VideoFormat,
+    progress: &mut impl MediaProgressReporter,
+) -> Result<()> {
     if frames.is_empty() {
         return Err(miette!(
             "cannot write {} with no frames",
@@ -371,7 +483,9 @@ fn write_video(
             .as_nanos()
     ));
     fs::create_dir_all(&temp_dir).into_diagnostic()?;
-    let result = write_video_inner(path, frames, framerate, format, &ffmpeg, &temp_dir);
+    let result = write_video_inner(
+        path, frames, framerate, format, &ffmpeg, &temp_dir, progress,
+    );
     let cleanup = fs::remove_dir_all(&temp_dir).into_diagnostic();
     result?;
     cleanup?;
@@ -404,7 +518,9 @@ fn write_video_inner(
     format: VideoFormat,
     ffmpeg: &Path,
     temp_dir: &Path,
+    progress: &mut impl MediaProgressReporter,
 ) -> Result<()> {
+    let total = frames.len();
     for (index, (frame, _)) in frames.iter().enumerate() {
         write_png(
             &temp_dir.join(format!(
@@ -413,6 +529,11 @@ fn write_video_inner(
             )),
             frame,
         )?;
+        progress.report(MediaProgress {
+            kind: MediaProgressKind::VideoFrames,
+            position: index + 1,
+            total,
+        });
     }
     let mut command = Command::new(ffmpeg);
     command
@@ -470,7 +591,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn converts_bgra_to_rgba() {
+    fn converts_bgra_to_rgba() -> Result<()> {
         let frame = Frame {
             width: 1,
             height: 1,
@@ -478,11 +599,109 @@ mod tests {
             format: PixelFormat::Bgra8,
             pixels: vec![1, 2, 3, 4],
         };
-        assert_eq!(frame.rgba().unwrap(), vec![3, 2, 1, 4]);
+        assert_eq!(frame.rgba()?, vec![3, 2, 1, 4]);
+        Ok(())
     }
 
     #[test]
     fn missing_program_lookup_returns_none() {
         assert!(which("betamax-definitely-not-installed").is_none());
+    }
+
+    #[test]
+    fn gif_writer_reports_frame_progress() -> Result<()> {
+        let path = temp_path("betamax-progress.gif");
+        let frames = test_frames();
+        let mut progress = RecordingProgress::default();
+
+        write_gif_with_progress(&path, &frames, &mut progress)?;
+
+        assert_eq!(
+            progress.events,
+            vec![
+                MediaProgress {
+                    kind: MediaProgressKind::Gif,
+                    position: 1,
+                    total: 2,
+                },
+                MediaProgress {
+                    kind: MediaProgressKind::Gif,
+                    position: 2,
+                    total: 2,
+                },
+            ]
+        );
+        let _ = fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn png_sequence_writer_reports_frame_progress() -> Result<()> {
+        let path = temp_path("betamax-progress-frames");
+        let frames = test_frames();
+        let mut progress = RecordingProgress::default();
+
+        write_png_sequence_with_progress(&path, &frames, &mut progress)?;
+
+        assert_eq!(
+            progress.events,
+            vec![
+                MediaProgress {
+                    kind: MediaProgressKind::PngSequence,
+                    position: 1,
+                    total: 2,
+                },
+                MediaProgress {
+                    kind: MediaProgressKind::PngSequence,
+                    position: 2,
+                    total: 2,
+                },
+            ]
+        );
+        let _ = fs::remove_dir_all(path);
+        Ok(())
+    }
+
+    fn test_frames() -> Vec<(Frame, Duration)> {
+        vec![
+            (
+                Frame {
+                    width: 1,
+                    height: 1,
+                    stride: 4,
+                    format: PixelFormat::Rgba8,
+                    pixels: vec![255, 0, 0, 255],
+                },
+                Duration::from_millis(20),
+            ),
+            (
+                Frame {
+                    width: 1,
+                    height: 1,
+                    stride: 4,
+                    format: PixelFormat::Rgba8,
+                    pixels: vec![0, 0, 255, 255],
+                },
+                Duration::from_millis(20),
+            ),
+        ]
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_nanos());
+        std::env::temp_dir().join(format!("{}-{suffix}-{name}", std::process::id(),))
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingProgress {
+        events: Vec<MediaProgress>,
+    }
+
+    impl MediaProgressReporter for RecordingProgress {
+        fn report(&mut self, progress: MediaProgress) {
+            self.events.push(progress);
+        }
     }
 }

--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -59,7 +59,9 @@ use settings::Settings;
 use crate::ghostty::{CaptureRequest, GhosttyFrameCapture, PixelSize, TerminalGrid};
 use crate::key::key_bytes;
 use crate::media::{
-    write_gif, write_json, write_mp4, write_png, write_png_sequence, write_webm, Frame,
+    write_gif_with_progress, write_json, write_mp4_with_progress, write_png,
+    write_png_sequence_with_progress, write_webm_with_progress, Frame, MediaProgressReporter,
+    NoMediaProgress,
 };
 use crate::output::{classify_outputs, Outputs};
 use crate::tape::{Command, Key, KeyCode, Tape, Value, WaitPattern, WaitTarget};
@@ -150,6 +152,8 @@ pub struct Runner<C = GhosttyFrameCapture> {
     options: RunOptions,
     /// Capture implementation used when any command or output needs rendered terminal state.
     capture: C,
+    /// Optional sink for deterministic media-writing progress.
+    media_progress: Box<dyn MediaProgressReporter>,
 }
 
 impl<C> std::fmt::Debug for Runner<C> {
@@ -158,6 +162,10 @@ impl<C> std::fmt::Debug for Runner<C> {
             .debug_struct("Runner")
             .field("options", &self.options)
             .field("capture", &std::any::type_name::<C>())
+            .field(
+                "media_progress",
+                &std::any::type_name::<Box<dyn MediaProgressReporter>>(),
+            )
             .finish()
     }
 }
@@ -168,6 +176,7 @@ impl Runner<GhosttyFrameCapture> {
         Self {
             options,
             capture: GhosttyFrameCapture,
+            media_progress: Box::new(NoMediaProgress),
         }
     }
 }
@@ -253,7 +262,20 @@ impl<C> Runner<C> {
     /// # }
     /// ```
     pub fn with_capture(options: RunOptions, capture: C) -> Self {
-        Self { options, capture }
+        Self {
+            options,
+            capture,
+            media_progress: Box::new(NoMediaProgress),
+        }
+    }
+
+    /// Attach a reporter for media-writing progress.
+    ///
+    /// The default runner only reports normal status lines. CLI callers can use this hook to render
+    /// progress bars without making terminal UI a core dependency.
+    pub fn with_media_progress(mut self, progress: impl MediaProgressReporter + 'static) -> Self {
+        self.media_progress = Box::new(progress);
+        self
     }
 }
 
@@ -420,7 +442,7 @@ where
                 ANSI_YELLOW,
                 format_args!("combining frames into gif {}", path.display()),
             );
-            write_gif(&path, &capture.frames)?;
+            write_gif_with_progress(&path, &capture.frames, &mut self.media_progress)?;
             self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.frame_dirs {
@@ -428,12 +450,17 @@ where
                 ANSI_YELLOW,
                 format_args!("writing frame sequence {}", path.display()),
             );
-            write_png_sequence(&path, &capture.frames)?;
+            write_png_sequence_with_progress(&path, &capture.frames, &mut self.media_progress)?;
             self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.mp4s {
             self.progress(ANSI_YELLOW, format_args!("encoding mp4 {}", path.display()));
-            write_mp4(&path, &capture.frames, settings.output_framerate())?;
+            write_mp4_with_progress(
+                &path,
+                &capture.frames,
+                settings.output_framerate(),
+                &mut self.media_progress,
+            )?;
             self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.webms {
@@ -441,7 +468,12 @@ where
                 ANSI_YELLOW,
                 format_args!("encoding webm {}", path.display()),
             );
-            write_webm(&path, &capture.frames, settings.output_framerate())?;
+            write_webm_with_progress(
+                &path,
+                &capture.frames,
+                settings.output_framerate(),
+                &mut self.media_progress,
+            )?;
             self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
 

--- a/crates/betamax/Cargo.toml
+++ b/crates/betamax/Cargo.toml
@@ -29,6 +29,7 @@ betamax-core.workspace = true
 clap.workspace = true
 clap-stdin.workspace = true
 glob.workspace = true
+indicatif.workspace = true
 interpolator.workspace = true
 libghostty-vt.workspace = true
 log.workspace = true

--- a/crates/betamax/src/commands/run.rs
+++ b/crates/betamax/src/commands/run.rs
@@ -5,9 +5,11 @@
 
 use std::path::PathBuf;
 
+use betamax_core::media::{MediaProgress, MediaProgressKind, MediaProgressReporter};
 use betamax_core::runner::{RunOptions, Runner};
 use betamax_core::tape::Tape;
 use clap_stdin::FileOrStdin;
+use indicatif::{ProgressBar, ProgressStyle};
 use miette::{IntoDiagnostic, Result};
 
 const ANSI_RESET: &str = "\x1b[0m";
@@ -55,7 +57,72 @@ impl Run {
             publish: self.publish,
             quiet: self.quiet,
         };
-        Runner::new(options).run(&tape)?;
+        let mut runner = Runner::new(options);
+        if !self.quiet {
+            runner = runner.with_media_progress(CliMediaProgress::default());
+        }
+        runner.run(&tape)?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct CliMediaProgress {
+    bar: Option<ProgressBar>,
+    kind: Option<MediaProgressKind>,
+}
+
+impl MediaProgressReporter for CliMediaProgress {
+    fn report(&mut self, progress: MediaProgress) {
+        self.ensure_bar(progress);
+        if let Some(bar) = &self.bar {
+            bar.set_position(progress.position as u64);
+            if progress.position == progress.total {
+                bar.finish_and_clear();
+                self.bar = None;
+                self.kind = None;
+            }
+        }
+    }
+}
+
+impl CliMediaProgress {
+    fn ensure_bar(&mut self, progress: MediaProgress) {
+        if self.kind != Some(progress.kind) {
+            if let Some(bar) = self.bar.take() {
+                bar.finish_and_clear();
+            }
+            let bar = ProgressBar::new(progress.total as u64);
+            bar.set_style(progress_style());
+            bar.set_message(progress_label(progress.kind));
+            self.bar = Some(bar);
+            self.kind = Some(progress.kind);
+        }
+    }
+}
+
+impl Drop for CliMediaProgress {
+    fn drop(&mut self) {
+        if let Some(bar) = self.bar.take() {
+            bar.finish_and_clear();
+        }
+    }
+}
+
+fn progress_style() -> ProgressStyle {
+    let style = ProgressStyle::with_template(
+        "{spinner:.blue} {msg} {pos}/{len} [{bar:32.cyan/blue}] {eta}",
+    );
+    match style {
+        Ok(style) => style.progress_chars("=> "),
+        Err(_) => ProgressStyle::default_bar().progress_chars("=> "),
+    }
+}
+
+fn progress_label(kind: MediaProgressKind) -> &'static str {
+    match kind {
+        MediaProgressKind::Gif => "encoding gif",
+        MediaProgressKind::PngSequence => "writing frames",
+        MediaProgressKind::VideoFrames => "preparing video frames",
     }
 }


### PR DESCRIPTION
## Summary

- add frame-level media progress events in betamax-core
- show indicatif progress bars from `betamax run` for GIF and frame-writing phases
- keep `--quiet` quiet and avoid adding terminal UI dependencies to betamax-core

## Validation

- `cargo fmt --all`
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`
- `cargo run -p betamax -- run examples/basic.tape`
