### PR TITLE
Align frame sizing with VHS

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Output examples/output/basic.gif
 Set Shell "bash"
 Set Theme "Aardvark Blue"
 Set FontSize 28
-Set Width 900
-Set Height 480
+Set Width 924
+Set Height 534
 Set Margin 12
 Set WindowBar Colorful
 Set BorderRadius 8

--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -356,14 +356,19 @@ where
         tracing::debug!(
             columns = settings.columns,
             rows = settings.rows,
-            width = settings.width,
-            height = settings.height,
+            output.width = settings.width,
+            output.height = settings.height,
+            canvas.width = settings.terminal_canvas_width(),
+            canvas.height = settings.terminal_canvas_height(),
             commands = tape.commands.len(),
             "starting captured tape run",
         );
         tracing::debug!("opening Ghostty frame capture");
         let mut terminal = self.capture.open(CaptureRequest {
-            canvas: PixelSize::new(settings.width, settings.height),
+            canvas: PixelSize::new(
+                settings.terminal_canvas_width(),
+                settings.terminal_canvas_height(),
+            ),
             grid: TerminalGrid::new(settings.columns, settings.rows),
             text: settings.text.clone(),
             theme: settings.theme.clone(),
@@ -908,6 +913,69 @@ mod tests {
     }
 
     #[test]
+    fn frame_style_reduces_terminal_canvas_like_vhs() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 900
+            Set Height 480
+            Set Margin 12
+            Set WindowBar Colorful
+            Set WindowBarSize 34
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(settings.width, 900);
+        assert_eq!(settings.height, 480);
+        assert_eq!(settings.terminal_canvas_width(), 876);
+        assert_eq!(settings.terminal_canvas_height(), 422);
+    }
+
+    #[test]
+    fn empty_margin_fill_disables_margin_like_vhs() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 900
+            Set Height 480
+            Set Margin 12
+            Set MarginFill ""
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(settings.terminal_canvas_width(), 900);
+        assert_eq!(settings.terminal_canvas_height(), 480);
+    }
+
+    #[test]
+    fn decoration_keeps_requested_output_dimensions() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 10
+            Set Height 8
+            Set Padding 0
+            Set Margin 1
+            Set WindowBar Colorful
+            Set WindowBarSize 2
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+        let frame = sized_test_frame(
+            settings.terminal_canvas_width(),
+            settings.terminal_canvas_height(),
+            [255, 0, 0, 255],
+        );
+
+        let decorated = settings.decorate_frame(&frame).unwrap();
+
+        assert_eq!(decorated.width, 10);
+        assert_eq!(decorated.height, 8);
+    }
+
+    #[test]
     fn unknown_settings_are_errors() {
         let tape = Tape::parse("Set Wdith 900").unwrap();
         let error = Settings::from_tape(&tape).unwrap_err().to_string();
@@ -969,12 +1037,17 @@ mod tests {
     }
 
     fn test_frame(pixel: [u8; 4]) -> Frame {
+        sized_test_frame(1, 1, pixel)
+    }
+
+    fn sized_test_frame(width: u32, height: u32, pixel: [u8; 4]) -> Frame {
+        let pixel_count = width as usize * height as usize;
         Frame {
-            width: 1,
-            height: 1,
-            stride: 4,
+            width,
+            height,
+            stride: width as usize * 4,
             format: crate::media::PixelFormat::Rgba8,
-            pixels: pixel.to_vec(),
+            pixels: pixel.repeat(pixel_count),
         }
     }
 }

--- a/crates/betamax-core/src/runner/pty.rs
+++ b/crates/betamax-core/src/runner/pty.rs
@@ -54,8 +54,8 @@ impl PtySession {
             .openpty(PtySize {
                 rows: settings.rows,
                 cols: settings.columns,
-                pixel_width: settings.width as u16,
-                pixel_height: settings.height as u16,
+                pixel_width: settings.terminal_canvas_width() as u16,
+                pixel_height: settings.terminal_canvas_height() as u16,
             })
             .map_err(|error| miette!("failed to open PTY: {error}"))?;
 

--- a/crates/betamax-core/src/runner/settings.rs
+++ b/crates/betamax-core/src/runner/settings.rs
@@ -23,9 +23,9 @@ use crate::tape::{Command, Tape, Value, WaitPattern};
 use crate::wait::regex_source;
 use crate::Result;
 
-/// Default raw terminal canvas width in pixels.
+/// Default final output width in pixels.
 const DEFAULT_WIDTH: u32 = 1200;
-/// Default raw terminal canvas height in pixels.
+/// Default final output height in pixels.
 const DEFAULT_HEIGHT: u32 = 600;
 /// Default capture cadence in frames per second.
 const DEFAULT_FRAMERATE: u16 = 50;
@@ -70,9 +70,9 @@ const CURSOR_BLINK_PHASES: usize = 2;
 pub(super) struct Settings {
     /// Shell command and optional explicit arguments from `Set Shell`.
     pub(super) shell: Vec<OsString>,
-    /// Output canvas width before margin/window decoration.
+    /// Final output width after margin/window decoration.
     pub(super) width: u32,
-    /// Output canvas height before margin/window decoration.
+    /// Final output height after margin/window decoration.
     pub(super) height: u32,
     /// Terminal grid columns derived from canvas width, padding, and text metrics.
     pub(super) columns: u16,
@@ -262,16 +262,49 @@ impl Settings {
         Ok(())
     }
 
+    /// Width of the terminal canvas before margin and window-bar decoration.
+    pub(super) fn terminal_canvas_width(&self) -> u32 {
+        self.width
+            .saturating_sub(self.effective_margin().saturating_mul(2))
+    }
+
+    /// Height of the terminal canvas before margin and window-bar decoration.
+    pub(super) fn terminal_canvas_height(&self) -> u32 {
+        self.height
+            .saturating_sub(self.effective_margin().saturating_mul(2))
+            .saturating_sub(self.window_bar_height())
+    }
+
+    /// VHS only applies margin when a margin fill is configured.
+    fn effective_margin(&self) -> u32 {
+        if self.style.margin_fill.is_empty() {
+            0
+        } else {
+            self.style.margin
+        }
+    }
+
+    /// Height reserved above the terminal canvas for the synthetic window bar.
+    fn window_bar_height(&self) -> u32 {
+        if self.style.window_bar.is_empty() {
+            0
+        } else {
+            self.style.window_bar_size
+        }
+    }
+
     /// Derive terminal rows and columns from pixel dimensions.
     ///
-    /// The terminal render area is the canvas minus text padding on each side. Each dimension is
-    /// clamped to at least one cell so pathological settings still create a valid PTY.
+    /// `Width` and `Height` describe the final output frame, matching VHS. Margin and window bar
+    /// decoration are subtracted first, then text padding is subtracted from the terminal canvas.
+    /// Each dimension is clamped to at least one cell so pathological settings still create a valid
+    /// PTY.
     fn apply_terminal_grid(&mut self) {
         let inner_width = self
-            .width
+            .terminal_canvas_width()
             .saturating_sub(self.text.padding.saturating_mul(2));
         let inner_height = self
-            .height
+            .terminal_canvas_height()
             .saturating_sub(self.text.padding.saturating_mul(2));
         self.columns = fit_cells(inner_width, self.text.cell_width());
         self.rows = fit_cells(inner_height, self.text.cell_height());
@@ -353,20 +386,11 @@ impl Settings {
     /// Invalid color strings are treated as the theme background instead of failing the render.
     /// That keeps old tapes usable while output styling is still gaining validation.
     pub(super) fn decorate_frame(&self, frame: &Frame) -> Result<Frame> {
-        let margin = self.style.margin;
-        let bar_height = if self.style.window_bar.is_empty() {
-            0
-        } else {
-            self.style.window_bar_size
-        };
+        let margin = self.effective_margin();
+        let bar_height = self.window_bar_height();
         let fill = parse_hex_color(&self.style.margin_fill).unwrap_or(self.theme.background);
         let bar = parse_hex_color(&self.style.window_bar_color).unwrap_or(self.theme.background);
-        let output_width = frame.width.saturating_add(margin.saturating_mul(2));
-        let output_height = frame
-            .height
-            .saturating_add(bar_height)
-            .saturating_add(margin.saturating_mul(2));
-        let mut output = SolidFrame::new(output_width, output_height, fill)?;
+        let mut output = SolidFrame::new(self.width, self.height, fill)?;
         output.blit(frame, margin, margin + bar_height)?;
         if bar_height > 0 {
             output.fill_rect(margin, margin, frame.width, bar_height, bar);

--- a/crates/betamax/README.md
+++ b/crates/betamax/README.md
@@ -76,8 +76,8 @@ Output examples/output/basic.state.json
 Set Shell "bash"
 Set Theme "Aardvark Blue"
 Set FontSize 28
-Set Width 900
-Set Height 480
+Set Width 924
+Set Height 534
 Set Margin 12
 Set WindowBar Colorful
 Set BorderRadius 8

--- a/docs/tape-reference.md
+++ b/docs/tape-reference.md
@@ -34,8 +34,8 @@ Common settings:
 | `FontSize`      | number                                     | `22`             | Pixels.                                     |
 | `LetterSpacing` | number                                     | `1`              | Additional pixels between cells.            |
 | `LineHeight`    | number                                     | `1`              | Multiplier applied to font size.            |
-| `Width`         | number                                     | `1200`           | Raw terminal canvas width in pixels.        |
-| `Height`        | number                                     | `600`            | Raw terminal canvas height in pixels.       |
+| `Width`         | number                                     | `1200`           | Final output width in pixels.               |
+| `Height`        | number                                     | `600`            | Final output height in pixels.              |
 | `Padding`       | number                                     | `60`             | Inner padding before terminal cells.        |
 | `Framerate`     | number                                     | `50`             | Capture cadence in frames per second.       |
 | `TypingSpeed`   | duration                                   | `50ms`           | Default delay between typed characters.     |
@@ -52,6 +52,11 @@ Common settings:
 
 Unknown settings and type mismatches are errors. For example, `Set Wdith 900` and
 `Set Width "wide"` fail before the shell starts instead of silently falling back to defaults.
+
+The terminal grid is derived after all settings are applied. Margin and window-bar decoration are
+subtracted from width and height first, then padding, font size, letter spacing, and line height
+determine the PTY columns and rows. Extremely small dimensions are clamped to at least one row and
+one column.
 
 For built-in shell names such as `bash`, `zsh`, and `fish`, Betamax starts a clean recording shell
 with startup files and history disabled where possible. Those shells use the VHS-style colored `>`

--- a/examples/basic.tape
+++ b/examples/basic.tape
@@ -5,8 +5,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Aardvark Blue"
 Set FontSize 28
-Set Width 900
-Set Height 480
+Set Width 924
+Set Height 538
 Set Margin 12
 Set WindowBar Colorful
 Set WindowBarSize 34

--- a/examples/clipboard-env.tape
+++ b/examples/clipboard-env.tape
@@ -7,8 +7,8 @@ Env BETAMAX_EXAMPLE clipboard-env
 Set Shell "bash"
 Set Theme "TokyoNight Night"
 Set FontSize 24
-Set Width 980
-Set Height 500
+Set Width 1004
+Set Height 554
 Set Margin 12
 Set WindowBar RingsRight
 Set BorderRadius 8

--- a/examples/hide-show.tape
+++ b/examples/hide-show.tape
@@ -5,8 +5,8 @@ Require printf
 Set Shell "bash"
 Set Theme "GitHub Dark"
 Set FontSize 24
-Set Width 940
-Set Height 500
+Set Width 968
+Set Height 558
 Set Margin 14
 Set WindowBar RingsRight
 Set BorderRadius 10

--- a/examples/keys.tape
+++ b/examples/keys.tape
@@ -5,8 +5,8 @@ Require printf
 Set Shell "bash"
 Set Theme "GitHub Dark"
 Set FontSize 24
-Set Width 940
-Set Height 500
+Set Width 964
+Set Height 554
 Set Margin 12
 Set WindowBar Colorful
 Set BorderRadius 8

--- a/examples/layout.tape
+++ b/examples/layout.tape
@@ -5,8 +5,8 @@ Require printf
 Set Shell "bash"
 Set Theme "GitHub Light Default"
 Set FontSize 24
-Set Width 980
-Set Height 520
+Set Width 1028
+Set Height 610
 Set Padding 72
 Set Margin 24
 Set MarginFill "#1d3557"

--- a/examples/outputs.tape
+++ b/examples/outputs.tape
@@ -8,8 +8,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Catppuccin Mocha"
 Set FontSize 24
-Set Width 940
-Set Height 500
+Set Width 964
+Set Height 554
 Set Margin 12
 Set WindowBar ColorfulRight
 Set BorderRadius 8

--- a/examples/quick-start.tape
+++ b/examples/quick-start.tape
@@ -7,8 +7,8 @@ Require cargo-binstall
 # Use the local Brownout Ghostty theme and a warm outer margin.
 Set Shell "bash"
 Set Theme "Betamax Brownout"
-Set Width 1000
-Set Height 820
+Set Width 1032
+Set Height 886
 Set Margin 16
 Set MarginFill "#20140d"
 Set WindowBar Colorful

--- a/examples/screenshot.tape
+++ b/examples/screenshot.tape
@@ -6,8 +6,8 @@ Require printf
 Set Shell "bash"
 Set Theme "TokyoNight Night"
 Set FontSize 24
-Set Width 900
-Set Height 460
+Set Width 924
+Set Height 514
 Set Margin 12
 Set WindowBar ColorfulRight
 Set BorderRadius 8

--- a/examples/scrollback.tape
+++ b/examples/scrollback.tape
@@ -6,8 +6,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Aardvark Blue"
 Set FontSize 22
-Set Width 900
-Set Height 360
+Set Width 924
+Set Height 414
 Set Padding 36
 Set Margin 12
 Set WindowBar Rings

--- a/examples/text-styles.tape
+++ b/examples/text-styles.tape
@@ -6,8 +6,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Dracula"
 Set FontSize 24
-Set Width 980
-Set Height 520
+Set Width 1008
+Set Height 578
 Set Margin 14
 Set WindowBar Colorful
 Set BorderRadius 8

--- a/examples/themes.tape
+++ b/examples/themes.tape
@@ -5,8 +5,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Dracula"
 Set FontSize 24
-Set Width 960
-Set Height 520
+Set Width 992
+Set Height 588
 Set Margin 16
 Set MarginFill "#111111"
 Set WindowBar Colorful

--- a/examples/video.tape
+++ b/examples/video.tape
@@ -7,8 +7,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Catppuccin Mocha"
 Set FontSize 24
-Set Width 900
-Set Height 480
+Set Width 924
+Set Height 534
 Set Margin 12
 Set WindowBar Colorful
 Set BorderRadius 8

--- a/examples/waits.tape
+++ b/examples/waits.tape
@@ -5,8 +5,8 @@ Require printf
 Set Shell "bash"
 Set Theme "Aardvark Blue"
 Set FontSize 24
-Set Width 940
-Set Height 500
+Set Width 964
+Set Height 554
 Set Margin 12
 Set WindowBar Rings
 Set BorderRadius 8

--- a/site/src/content/docs/authoring/themes.mdx
+++ b/site/src/content/docs/authoring/themes.mdx
@@ -32,13 +32,13 @@ not because it has special behavior in the renderer.
 
 ## Layout Settings
 
-These settings affect the raw terminal canvas and PTY grid:
+These settings affect the final output frame and PTY grid:
 
 | Setting         | Default          | Purpose                                     |
 | --------------- | ---------------- | ------------------------------------------- |
-| `Width`         | `1200`           | Raw terminal canvas width in pixels         |
-| `Height`        | `600`            | Raw terminal canvas height in pixels        |
-| `Padding`       | `60`             | Space between cells and the raw canvas edge |
+| `Width`         | `1200`           | Final output width in pixels                |
+| `Height`        | `600`            | Final output height in pixels               |
+| `Padding`       | `60`             | Space between cells and terminal edge       |
 | `FontFamily`    | `JetBrains Mono` | Preferred font family                       |
 | `FontSize`      | `22`             | Font size in pixels                         |
 | `LetterSpacing` | `1`              | Extra pixels between terminal cells         |

--- a/site/src/content/docs/reference/tape-reference.mdx
+++ b/site/src/content/docs/reference/tape-reference.mdx
@@ -54,9 +54,9 @@ an error rather than a quiet fallback.
 | `FontSize`      | number                | `22`             | Font size in pixels                                                   |
 | `LetterSpacing` | number                | `1`              | Extra pixels between terminal cells                                   |
 | `LineHeight`    | number                | `1`              | Multiplier applied to the font size                                   |
-| `Width`         | number                | `1200`           | Raw terminal canvas width before margin/window decoration             |
-| `Height`        | number                | `600`            | Raw terminal canvas height before margin/window decoration            |
-| `Padding`       | number                | `60`             | Inner padding between the terminal cells and raw canvas edge          |
+| `Width`         | number                | `1200`           | Final output width in pixels                                          |
+| `Height`        | number                | `600`            | Final output height in pixels                                         |
+| `Padding`       | number                | `60`             | Inner padding between the terminal cells and terminal canvas edge     |
 | `Framerate`     | number                | `50`             | Capture cadence in frames per second                                  |
 | `TypingSpeed`   | duration              | `50ms`           | Delay between characters typed by `Type`                              |
 | `PlaybackSpeed` | number                | `1.0`            | Output playback multiplier; does not speed up command execution       |
@@ -70,9 +70,10 @@ an error rather than a quiet fallback.
 | `WindowBarSize` | number                | `30`             | Window bar height in pixels                                           |
 | `BorderRadius`  | number                | `0`              | Rounded-corner mask radius in pixels                                  |
 
-The terminal grid is derived after all settings are applied. Width, height, padding, font size,
-letter spacing, and line height determine the PTY columns and rows. Extremely small dimensions are
-clamped to at least one row and one column.
+The terminal grid is derived after all settings are applied. Margin and window-bar decoration are
+subtracted from width and height first, then padding, font size, letter spacing, and line height
+determine the PTY columns and rows. Extremely small dimensions are clamped to at least one row and
+one column.
 
 ## Command Reference
 


### PR DESCRIPTION
# Pull Request

## Summary

Align Betamax frame sizing with VHS for margin, padding, and window-bar settings:

- Treat `Set Width` and `Set Height` as final output dimensions.
- Subtract effective margin and window-bar decoration before deriving the terminal canvas and PTY grid.
- Compose decorated frames back into the requested final output size.
- Recalculate Betamax-authored example tape dimensions so existing README/site framing stays the same under the VHS-compatible interpretation.
- Update docs to describe width/height as final output dimensions.

Homepage GIF comparison for `site/public/assets/betamax-hero-quick-start.gif`:

- Pre-change LFS asset: `940x680`, `137` frames, real `GIF89a` content.
- Post-change render from `site/quick-start.tape`: `940x680`, `137` frames, real `GIF89a` content.

## Validation

```sh
mise exec -- cargo test -p betamax-core
mise exec -- cargo test
mise exec -- cargo run --quiet -- validate examples/*.tape site/quick-start.tape docs.tape crates/betamax/src/commands/new.tape
npx markdownlint-cli2 docs/tape-reference.md README.md crates/betamax/README.md
pnpm install --frozen-lockfile
pnpm docs:build
```

Also rendered a copy of `site/quick-start.tape` to `/tmp/betamax-homepage-gif/post.gif` and compared it with the LFS-smudged pre-change homepage GIF using `ffprobe`.

## Notes

The PR does not replace the tracked homepage GIF asset; it only verifies that a fresh render keeps the center homepage GIF at the same display size.
