### PR TITLE
Fix Ubuntu SIGILL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
 
       - name: Cache Rust builds
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust-no-target
+          cache-targets: false
 
       - name: Check formatting
         run: mise run fmt-check
@@ -105,6 +108,9 @@ jobs:
 
       - name: Cache Rust builds
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust-no-target
+          cache-targets: false
 
       - name: Check workspace
         run: mise run cargo-check
@@ -151,6 +157,9 @@ jobs:
 
       - name: Cache Rust builds
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust-no-target
+          cache-targets: false
 
       - name: Package crates
         run: mise run package
@@ -209,6 +218,9 @@ jobs:
 
       - name: Cache Rust builds
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          prefix-key: v1-rust-no-target
+          cache-targets: false
 
       - name: Install cargo maintenance tools
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10


### PR DESCRIPTION
## Summary

- stop restoring/saving Cargo `target/` artifacts in CI rust-cache steps
- bump the rust-cache prefix so existing native target archives are not reused

## Why

Ubuntu PR jobs are failing with SIGILL in Ghostty-linked doctests and smoke runs while `main` passed the same checks. The failing jobs restore full-match Rust target caches, and `libghostty-vt-sys` builds native Zig code for the current host CPU on native builds. Reusing those artifacts across GitHub runner classes can execute instructions the current runner does not support.

## Validation

- `mise run doc-test`
- `mise run smoke`
- parsed `.github/workflows/ci.yml` with Ruby/Psych
