### PR TITLE
Add media captions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 site/public/assets/betamax-hero-terminal.png filter=lfs diff=lfs merge=lfs -text
 site/public/assets/betamax-hero-quick-start.gif filter=lfs diff=lfs merge=lfs -text
+site/public/assets/betamax-captions.gif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The checked-in examples are small smoke-test tapes that demonstrate core behavio
 | `examples/waits.tape`            | line, screen, regex, and default prompt waits  | `waits.gif`         |
 | `examples/keys.tape`             | key commands, repeats, editing, and interrupt  | `keys.gif`          |
 | `examples/clipboard-env.tape`    | `Env`, `Copy`, and `Paste`                     | `clipboard-env.gif` |
+| `examples/captions.tape`         | visual captions for review media               | `captions.*`        |
 | `examples/outputs.tape`          | GIF, PNG, JSON, screenshot, state, frame dir   | `outputs.*`         |
 | `examples/scrollback.tape`       | scrollback-inclusive state JSON                | `scrollback.*`      |
 | `examples/text-styles.tape`      | ANSI styles, truecolor, and styled state spans | `text-styles.*`     |

--- a/crates/betamax-core/src/runner/capture.rs
+++ b/crates/betamax-core/src/runner/capture.rs
@@ -22,7 +22,12 @@ pub(super) struct CaptureState {
     ///
     /// The frame pixels represent the raw terminal render before final margin/window decoration.
     /// Decoration is applied once at the end so all outputs share the same styling path.
-    pub(super) frames: Vec<(Frame, Duration)>,
+    pub(super) frames: Vec<(CapturedFrame, Duration)>,
+    /// Caption rendered onto later media frames.
+    ///
+    /// This is presentation metadata only. It does not affect PTY execution, terminal state, or
+    /// semantic wait matching.
+    pub(super) caption: Option<String>,
 }
 
 impl Default for CaptureState {
@@ -30,8 +35,18 @@ impl Default for CaptureState {
         Self {
             visible: true,
             frames: Vec::new(),
+            caption: None,
         }
     }
+}
+
+/// Raw captured terminal frame plus presentation metadata for final media decoration.
+#[derive(Debug, Clone)]
+pub(super) struct CapturedFrame {
+    /// Raw terminal frame before final margin/window/caption decoration.
+    pub(super) frame: Frame,
+    /// Caption active when this frame was captured.
+    pub(super) caption: Option<String>,
 }
 
 /// Capture one raw terminal frame with runner-controlled cursor blinking.
@@ -48,19 +63,25 @@ pub(super) fn capture_frame(
     terminal.capture_frame_with_cursor(cursor_visible)
 }
 
-/// Append one visible frame or extend the previous frame when pixels have not changed.
+/// Append one visible frame or extend the previous frame when pixels and caption have not changed.
 ///
 /// This preserves wall-clock dwell time for static terminal states. Without delay coalescing, a
 /// `Sleep 2s` after the final output only contributes as many nominal frame delays as the renderer
 /// can sample during those two seconds, which can make GIFs play much faster than the tape timing.
+///
+/// Captions are included in the coalescing key even though they are not terminal pixels yet. A
+/// repeated terminal frame with a new caption is a visible media change after final decoration.
 pub(super) fn append_visible_frame(capture: &mut CaptureState, frame: Frame, delay: Duration) {
+    let caption = capture.caption.clone();
     if let Some((last_frame, last_delay)) = capture.frames.last_mut() {
-        if frames_equal(last_frame, &frame) {
+        if last_frame.caption == caption && frames_equal(&last_frame.frame, &frame) {
             *last_delay += delay;
             return;
         }
     }
-    capture.frames.push((frame, delay));
+    capture
+        .frames
+        .push((CapturedFrame { frame, caption }, delay));
 }
 
 /// Append the final still frame for animated outputs when it differs from the last visible frame.
@@ -72,7 +93,13 @@ pub(super) fn append_final_gif_frame(capture: &mut CaptureState, frame: Frame, d
         append_visible_frame(capture, frame.clone(), delay);
     }
     if capture.frames.is_empty() {
-        capture.frames.push((frame, delay));
+        capture.frames.push((
+            CapturedFrame {
+                frame,
+                caption: capture.caption.clone(),
+            },
+            delay,
+        ));
     }
 }
 
@@ -88,4 +115,37 @@ pub(super) fn frames_equal(left: &Frame, right: &Frame) -> bool {
         && left.stride == right.stride
         && left.format == right.format
         && left.pixels == right.pixels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::PixelFormat;
+
+    #[test]
+    fn caption_changes_keep_repeated_frames_separate() {
+        let frame = test_frame();
+        let mut capture = CaptureState {
+            caption: Some("First step".to_string()),
+            ..Default::default()
+        };
+
+        append_visible_frame(&mut capture, frame.clone(), Duration::from_millis(20));
+        capture.caption = Some("Second step".to_string());
+        append_visible_frame(&mut capture, frame.clone(), Duration::from_millis(20));
+
+        assert_eq!(capture.frames.len(), 2);
+        assert_eq!(capture.frames[0].0.caption.as_deref(), Some("First step"));
+        assert_eq!(capture.frames[1].0.caption.as_deref(), Some("Second step"));
+    }
+
+    fn test_frame() -> Frame {
+        Frame {
+            width: 1,
+            height: 1,
+            stride: 4,
+            format: PixelFormat::Rgba8,
+            pixels: vec![255, 0, 0, 255],
+        }
+    }
 }

--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -406,20 +406,22 @@ where
         tracing::debug!("draining final PTY output");
         session.drain_into(&mut terminal, FINAL_COMMAND_IDLE)?;
         tracing::trace!("drained final PTY output");
-        let frame = settings.decorate_frame(&capture_frame(
-            &mut terminal,
-            &settings,
-            capture.frames.len(),
-        )?)?;
-        settings.decorate_frames(&mut capture.frames)?;
-        if !outputs.gifs.is_empty()
+        let final_raw_frame = capture_frame(&mut terminal, &settings, capture.frames.len())?;
+        let writes_animated_media = !outputs.gifs.is_empty()
             || !outputs.mp4s.is_empty()
             || !outputs.webms.is_empty()
-            || !outputs.frame_dirs.is_empty()
-        {
-            append_final_gif_frame(&mut capture, frame.clone(), settings.frame_delay());
+            || !outputs.frame_dirs.is_empty();
+        if writes_animated_media {
+            append_final_gif_frame(
+                &mut capture,
+                final_raw_frame.clone(),
+                settings.frame_delay(),
+            );
             settings.apply_loop_offset(&mut capture.frames);
         }
+        let frame =
+            settings.decorate_frame_with_caption(&final_raw_frame, capture.caption.as_deref())?;
+        let media_frames = decorate_captured_frames(&settings, &mut capture)?;
 
         let output_paths = outputs.paths();
         tracing::debug!("reading final terminal state");
@@ -447,7 +449,7 @@ where
                 ANSI_YELLOW,
                 format_args!("combining frames into gif {}", path.display()),
             );
-            write_gif_with_progress(&path, &capture.frames, &mut self.media_progress)?;
+            write_gif_with_progress(&path, &media_frames, &mut self.media_progress)?;
             self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.frame_dirs {
@@ -455,14 +457,14 @@ where
                 ANSI_YELLOW,
                 format_args!("writing frame sequence {}", path.display()),
             );
-            write_png_sequence_with_progress(&path, &capture.frames, &mut self.media_progress)?;
+            write_png_sequence_with_progress(&path, &media_frames, &mut self.media_progress)?;
             self.progress(ANSI_GREEN, format_args!("wrote {}", path.display()));
         }
         for path in outputs.mp4s {
             self.progress(ANSI_YELLOW, format_args!("encoding mp4 {}", path.display()));
             write_mp4_with_progress(
                 &path,
-                &capture.frames,
+                &media_frames,
                 settings.output_framerate(),
                 &mut self.media_progress,
             )?;
@@ -475,7 +477,7 @@ where
             );
             write_webm_with_progress(
                 &path,
-                &capture.frames,
+                &media_frames,
                 settings.output_framerate(),
                 &mut self.media_progress,
             )?;
@@ -550,15 +552,20 @@ where
                 session.write_all(clipboard.as_bytes())?;
                 session.drain_for(terminal, settings.frame_delay(), settings, capture)?;
             }
+            Command::Caption(text) => {
+                // Caption changes are presentation state only. They intentionally do not drain,
+                // wait, or capture because the PTY has not changed; the next visual frame applies
+                // the active caption during decoration.
+                capture.caption = active_caption(text);
+            }
             Command::Screenshot(path) => {
                 session.drain_into(terminal, CHECKPOINT_IDLE)?;
                 write_png(
                     path,
-                    &settings.decorate_frame(&capture_frame(
-                        terminal,
-                        settings,
-                        capture.frames.len(),
-                    )?)?,
+                    &settings.decorate_frame_with_caption(
+                        &capture_frame(terminal, settings, capture.frames.len())?,
+                        capture.caption.as_deref(),
+                    )?,
                 )?;
             }
             Command::State(path) => {
@@ -627,6 +634,7 @@ where
                 }
                 Command::Copy(text) => clipboard = text.clone(),
                 Command::Paste => session.write_all(clipboard.as_bytes())?,
+                Command::Caption(_) => {}
                 Command::Env { .. }
                 | Command::Hide
                 | Command::Output(_)
@@ -679,7 +687,7 @@ where
             | Command::Env { .. } => (ANSI_DIM, "setup"),
             Command::Sleep(_) | Command::Wait { .. } => (ANSI_YELLOW, "wait"),
             Command::Screenshot(_) | Command::State(_) => (ANSI_YELLOW, "capture"),
-            Command::Hide | Command::Show => (ANSI_DIM, "display"),
+            Command::Hide | Command::Show | Command::Caption(_) => (ANSI_DIM, "display"),
             _ => (ANSI_CYAN, "run"),
         };
         self.progress(
@@ -696,6 +704,26 @@ where
             println!("{style}{args}{ANSI_RESET}");
         }
     }
+}
+
+fn decorate_captured_frames(
+    settings: &Settings,
+    capture: &mut CaptureState,
+) -> Result<Vec<(Frame, Duration)>> {
+    settings.decorate_captioned_frames(
+        capture
+            .frames
+            .drain(..)
+            .map(|(captured, delay)| (captured.frame, captured.caption, delay)),
+    )
+}
+
+/// Convert parsed caption text into the active presentation state.
+///
+/// Empty or whitespace-only captions clear the overlay. Non-empty captions keep their original
+/// spacing so authors can intentionally align short labels within the rendered overlay.
+fn active_caption(text: &str) -> Option<String> {
+    (!text.trim().is_empty()).then(|| text.to_string())
 }
 
 fn describe_command(command: &Command) -> String {
@@ -748,6 +776,7 @@ fn describe_command(command: &Command) -> String {
         Command::Env { key, .. } => format!("Env {key} <value>"),
         Command::Copy(text) => format!("Copy \"{}\"", describe_text(text)),
         Command::Paste => "Paste".to_string(),
+        Command::Caption(text) => format!("Caption \"{}\"", describe_text(text)),
         Command::Source(path) => format!("Source {}", path.display()),
         Command::Screenshot(path) => format!("Screenshot {}", path.display()),
         Command::State(path) => format!("State {}", path.display()),
@@ -768,6 +797,7 @@ fn command_kind(command: &Command) -> &'static str {
         Command::Env { .. } => "Env",
         Command::Copy(_) => "Copy",
         Command::Paste => "Paste",
+        Command::Caption(_) => "Caption",
         Command::Screenshot(_) => "Screenshot",
         Command::State(_) => "State",
         Command::Source(_) => "Source",
@@ -857,7 +887,7 @@ fn describe_text(text: &str) -> String {
 mod tests {
     use super::*;
     use crate::media::Frame;
-    use crate::runner::capture::frames_equal;
+    use crate::runner::capture::{frames_equal, CapturedFrame};
 
     #[test]
     fn uses_vhs_typography_defaults() {
@@ -969,10 +999,37 @@ mod tests {
             [255, 0, 0, 255],
         );
 
-        let decorated = settings.decorate_frame(&frame).unwrap();
+        let decorated = settings.decorate_frame_with_caption(&frame, None).unwrap();
 
         assert_eq!(decorated.width, 10);
         assert_eq!(decorated.height, 8);
+    }
+
+    #[test]
+    fn caption_decoration_preserves_dimensions_and_changes_pixels() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 180
+            Set Height 120
+            Set Padding 0
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+        let frame = sized_test_frame(
+            settings.terminal_canvas_width(),
+            settings.terminal_canvas_height(),
+            [255, 0, 0, 255],
+        );
+
+        let plain = settings.decorate_frame_with_caption(&frame, None).unwrap();
+        let captioned = settings
+            .decorate_frame_with_caption(&frame, Some("Review checkpoint"))
+            .unwrap();
+
+        assert_eq!(captioned.width, plain.width);
+        assert_eq!(captioned.height, plain.height);
+        assert_ne!(captioned.pixels, plain.pixels);
     }
 
     #[test]
@@ -1013,13 +1070,20 @@ mod tests {
         let cleanup_frame = test_frame([0, 255, 0, 255]);
         let mut capture = CaptureState {
             visible: false,
-            frames: vec![(visible_frame.clone(), Duration::from_millis(20))],
+            frames: vec![(
+                CapturedFrame {
+                    frame: visible_frame.clone(),
+                    caption: None,
+                },
+                Duration::from_millis(20),
+            )],
+            caption: None,
         };
 
         append_final_gif_frame(&mut capture, cleanup_frame, Duration::from_millis(20));
 
         assert_eq!(capture.frames.len(), 1);
-        assert!(frames_equal(&capture.frames[0].0, &visible_frame));
+        assert!(frames_equal(&capture.frames[0].0.frame, &visible_frame));
     }
 
     #[test]
@@ -1033,7 +1097,7 @@ mod tests {
 
         assert_eq!(capture.frames.len(), 1);
         assert_eq!(capture.frames[0].1, Duration::from_millis(60));
-        assert!(frames_equal(&capture.frames[0].0, &frame));
+        assert!(frames_equal(&capture.frames[0].0.frame, &frame));
     }
 
     fn test_frame(pixel: [u8; 4]) -> Frame {

--- a/crates/betamax-core/src/runner/settings.rs
+++ b/crates/betamax-core/src/runner/settings.rs
@@ -14,6 +14,7 @@ use std::env;
 use std::ffi::OsString;
 use std::time::Duration;
 
+use cosmic_text::{Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight};
 use miette::miette;
 use regex::Regex;
 
@@ -60,6 +61,20 @@ const WINDOW_BUTTON_GAP_RADIUS_MULTIPLIER: u32 = 3;
 const MIN_EFFECTIVE_FRAMERATE: u16 = 1;
 /// Cursor blink uses a two-phase on/off cycle.
 const CURSOR_BLINK_PHASES: usize = 2;
+/// Caption font size relative to the tape font size.
+const CAPTION_FONT_SCALE: f32 = 0.9;
+/// Minimum readable caption font size.
+const MIN_CAPTION_FONT_SIZE: f32 = 14.0;
+/// Caption line height relative to caption font size.
+const CAPTION_LINE_HEIGHT: f32 = 1.35;
+/// Horizontal caption padding relative to caption font size.
+const CAPTION_HORIZONTAL_PADDING: f32 = 0.75;
+/// Vertical caption padding relative to caption font size.
+const CAPTION_VERTICAL_PADDING: f32 = 0.45;
+/// Caption background alpha. The output frame remains fully opaque after blending.
+const CAPTION_BACKGROUND_ALPHA: u8 = 0xdd;
+/// Denominator for 8-bit alpha blending.
+const ALPHA_DENOMINATOR: u16 = 255;
 
 /// Shell command and all derived execution, rendering, timing, and styling settings.
 ///
@@ -354,7 +369,7 @@ impl Settings {
     /// This is applied after the final frame has been appended. Static outputs ignore loop offset.
     /// Fractional offsets in `0.0..=1.0` mean a percentage of the frame list. Other values are
     /// interpreted as seconds at the capture framerate to match VHS's time-based option.
-    pub(super) fn apply_loop_offset(&self, frames: &mut [(Frame, Duration)]) {
+    pub(super) fn apply_loop_offset<T>(&self, frames: &mut [(T, Duration)]) {
         if frames.len() < 2 || self.loop_offset == 0.0 {
             return;
         }
@@ -368,24 +383,54 @@ impl Settings {
         frames.rotate_left(offset % len);
     }
 
-    /// Apply margin, window-bar, and rounded-corner decoration to all captured frames.
+    /// Decorate a single raw terminal frame and optionally render a caption overlay.
     ///
-    /// The function drains and replaces the frame vector so callers cannot accidentally mix raw and
-    /// decorated frames. Delays are preserved exactly.
-    pub(super) fn decorate_frames(&self, frames: &mut Vec<(Frame, Duration)>) -> Result<()> {
-        let mut decorated = Vec::with_capacity(frames.len());
-        for (frame, delay) in frames.drain(..) {
-            decorated.push((self.decorate_frame(&frame)?, delay));
-        }
-        *frames = decorated;
-        Ok(())
+    /// Captions are presentation metadata. They are applied after the terminal has rendered, using
+    /// the final output dimensions, and therefore do not affect PTY size, terminal state, or waits.
+    pub(super) fn decorate_frame_with_caption(
+        &self,
+        frame: &Frame,
+        caption: Option<&str>,
+    ) -> Result<Frame> {
+        let mut caption_renderer = CaptionRenderer::new();
+        self.decorate_frame_with_caption_renderer(frame, caption, &mut caption_renderer)
     }
 
-    /// Decorate a single raw terminal frame.
+    /// Decorate captured frames with one reusable caption renderer.
     ///
-    /// Invalid color strings are treated as the theme background instead of failing the render.
-    /// That keeps old tapes usable while output styling is still gaining validation.
-    pub(super) fn decorate_frame(&self, frame: &Frame) -> Result<Frame> {
+    /// Animated outputs may render hundreds of frames with the same caption text and font. Keeping
+    /// one renderer here preserves the shaping and glyph caches for the batch without making cache
+    /// lifetime part of `Settings`.
+    pub(super) fn decorate_captioned_frames(
+        &self,
+        frames: impl IntoIterator<Item = (Frame, Option<String>, Duration)>,
+    ) -> Result<Vec<(Frame, Duration)>> {
+        let mut caption_renderer = CaptionRenderer::new();
+        let mut decorated = Vec::new();
+        for (frame, caption, delay) in frames {
+            decorated.push((
+                self.decorate_frame_with_caption_renderer(
+                    &frame,
+                    caption.as_deref(),
+                    &mut caption_renderer,
+                )?,
+                delay,
+            ));
+        }
+        Ok(decorated)
+    }
+
+    /// Decorate a frame using a caller-owned caption renderer cache.
+    ///
+    /// Decoration happens in final output coordinates: margin, window bar, rounded mask, then
+    /// caption overlay. Keeping captions last makes them independent from terminal canvas sizing
+    /// and guarantees the same overlay path for final PNGs, screenshots, GIFs, and videos.
+    fn decorate_frame_with_caption_renderer(
+        &self,
+        frame: &Frame,
+        caption: Option<&str>,
+        caption_renderer: &mut CaptionRenderer,
+    ) -> Result<Frame> {
         let margin = self.effective_margin();
         let bar_height = self.window_bar_height();
         let fill = parse_hex_color(&self.style.margin_fill).unwrap_or(self.theme.background);
@@ -411,7 +456,152 @@ impl Settings {
                 fill,
             );
         }
+        if let Some(caption) = caption.filter(|caption| !caption.trim().is_empty()) {
+            self.draw_caption(&mut output, caption, caption_renderer);
+        }
         Ok(output.into_frame())
+    }
+
+    /// Draw a caption into the final decorated frame.
+    ///
+    /// The background is alpha-blended into the opaque output frame before text is drawn. This
+    /// keeps output formats simple while still making captions readable over arbitrary terminal
+    /// content.
+    fn draw_caption(
+        &self,
+        output: &mut SolidFrame,
+        caption: &str,
+        caption_renderer: &mut CaptionRenderer,
+    ) {
+        let Some(layout) = self.caption_layout() else {
+            return;
+        };
+        output.fill_rect_alpha(
+            layout.x,
+            layout.y,
+            layout.width,
+            layout.height,
+            self.theme.background,
+            CAPTION_BACKGROUND_ALPHA,
+        );
+        caption_renderer.draw(output, caption, layout, &self.text, self.theme.foreground);
+    }
+
+    /// Compute caption geometry in final output-frame coordinates.
+    ///
+    /// The overlay spans the decorated content width inside the outer margin and is anchored to the
+    /// bottom of the final output. It may cover terminal pixels by design; tapes that need more
+    /// room should increase height, margin, or padding instead of changing PTY behavior.
+    fn caption_layout(&self) -> Option<CaptionLayout> {
+        let margin = self.effective_margin();
+        let width = self.width.saturating_sub(margin.saturating_mul(2));
+        if width == 0 || self.height == 0 {
+            return None;
+        }
+
+        let font_size = (self.text.font_size * CAPTION_FONT_SCALE).max(MIN_CAPTION_FONT_SIZE);
+        let line_height = (font_size * CAPTION_LINE_HEIGHT).ceil();
+        let horizontal_padding = (font_size * CAPTION_HORIZONTAL_PADDING).ceil() as u32;
+        let vertical_padding = (font_size * CAPTION_VERTICAL_PADDING).ceil() as u32;
+        let height = (line_height as u32)
+            .saturating_add(vertical_padding.saturating_mul(2))
+            .min(self.height);
+        let text_width = width.saturating_sub(horizontal_padding.saturating_mul(2));
+        if text_width == 0 {
+            return None;
+        }
+
+        let y = self.height.saturating_sub(margin).saturating_sub(height);
+        Some(CaptionLayout {
+            x: margin,
+            y,
+            width,
+            height,
+            text_x: margin.saturating_add(horizontal_padding),
+            text_y: y.saturating_add(vertical_padding),
+            text_width,
+            text_height: height.saturating_sub(vertical_padding.saturating_mul(2)),
+            font_size,
+            line_height,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CaptionLayout {
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+    text_x: u32,
+    text_y: u32,
+    text_width: u32,
+    text_height: u32,
+    font_size: f32,
+    line_height: f32,
+}
+
+/// Text renderer for caption overlays.
+///
+/// This owns `cosmic_text`'s mutable shaping and raster caches. The renderer is kept outside
+/// `Settings` so decoration remains a pure operation from caller input to media frame, while
+/// callers that render many frames can still reuse the expensive font state.
+struct CaptionRenderer {
+    /// Font database and shaping context.
+    font_system: FontSystem,
+    /// Glyph raster cache.
+    swash_cache: SwashCache,
+}
+
+impl CaptionRenderer {
+    /// Create a caption renderer with reusable font and glyph caches.
+    fn new() -> Self {
+        Self {
+            font_system: FontSystem::new(),
+            swash_cache: SwashCache::new(),
+        }
+    }
+
+    /// Draw caption text into the given layout.
+    ///
+    /// The bounded text buffer clips overflow instead of resizing the media frame. That matches
+    /// the tape contract: captions are annotations on fixed-size output, not layout inputs.
+    fn draw(
+        &mut self,
+        target: &mut SolidFrame,
+        caption: &str,
+        layout: CaptionLayout,
+        text_settings: &TextSettings,
+        color: libghostty_vt::style::RgbColor,
+    ) {
+        let metrics = Metrics::new(layout.font_size, layout.line_height);
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+        let mut buffer = buffer.borrow_with(&mut self.font_system);
+        let family = text_settings
+            .font_family
+            .as_deref()
+            .map(Family::Name)
+            .unwrap_or(Family::Monospace);
+        let attrs = Attrs::new().family(family).weight(Weight::BOLD);
+
+        buffer.set_size(
+            Some(layout.text_width as f32),
+            Some(layout.text_height as f32),
+        );
+        buffer.set_text(caption, &attrs, Shaping::Advanced, None);
+        buffer.draw(
+            &mut self.swash_cache,
+            Color::rgb(color.r, color.g, color.b),
+            |glyph_x, glyph_y, width, height, glyph_color| {
+                target.blend_rect(
+                    layout.text_x as i32 + glyph_x,
+                    layout.text_y as i32 + glyph_y,
+                    width,
+                    height,
+                    glyph_color,
+                );
+            },
+        );
     }
 }
 
@@ -475,10 +665,11 @@ impl SolidFrame {
         height: u32,
         color: libghostty_vt::style::RgbColor,
     ) {
-        let x1 = x.saturating_add(width).min(self.width);
-        let y1 = y.saturating_add(height).min(self.height);
-        for yy in y..y1 {
-            for xx in x..x1 {
+        let Some((x0, y0, x1, y1)) = self.clipped_rect(x as i32, y as i32, width, height) else {
+            return;
+        };
+        for yy in y0..y1 {
+            for xx in x0..x1 {
                 let offset = self.offset(xx, yy);
                 self.pixels[offset..offset + BYTES_PER_PIXEL].copy_from_slice(&[
                     color.r,
@@ -486,6 +677,48 @@ impl SolidFrame {
                     color.b,
                     OPAQUE_ALPHA,
                 ]);
+            }
+        }
+    }
+
+    /// Fill a clipped rectangle with alpha blending.
+    ///
+    /// Caption backgrounds are composited onto an opaque frame instead of introducing transparent
+    /// output pixels, because the media encoders currently treat rendered frames as opaque RGBA.
+    fn fill_rect_alpha(
+        &mut self,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        color: libghostty_vt::style::RgbColor,
+        alpha: u8,
+    ) {
+        let Some((x0, y0, x1, y1)) = self.clipped_rect(x as i32, y as i32, width, height) else {
+            return;
+        };
+        for yy in y0..y1 {
+            for xx in x0..x1 {
+                self.blend_pixel(xx, yy, color.r, color.g, color.b, alpha);
+            }
+        }
+    }
+
+    /// Alpha-blend a glyph rectangle into the frame.
+    ///
+    /// `cosmic_text` reports glyph rectangles in signed coordinates relative to the text origin.
+    /// Clipping here lets shaped glyphs extend beyond the overlay bounds without panicking.
+    fn blend_rect(&mut self, x: i32, y: i32, width: u32, height: u32, color: Color) {
+        let [r, g, b, a] = color.as_rgba();
+        if a == 0 {
+            return;
+        }
+        let Some((x0, y0, x1, y1)) = self.clipped_rect(x, y, width, height) else {
+            return;
+        };
+        for yy in y0..y1 {
+            for xx in x0..x1 {
+                self.blend_pixel(xx, yy, r, g, b, a);
             }
         }
     }
@@ -595,6 +828,37 @@ impl SolidFrame {
     /// Return the byte offset for a pixel in the tightly packed RGBA buffer.
     fn offset(&self, x: u32, y: u32) -> usize {
         ((y as usize * self.width as usize) + x as usize) * BYTES_PER_PIXEL
+    }
+
+    /// Return a clipped rectangle as `(x0, y0, x1, y1)`.
+    fn clipped_rect(
+        &self,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+    ) -> Option<(u32, u32, u32, u32)> {
+        let x0 = x.max(0) as u32;
+        let y0 = y.max(0) as u32;
+        let x1 = x.saturating_add(width as i32).clamp(0, self.width as i32) as u32;
+        let y1 = y.saturating_add(height as i32).clamp(0, self.height as i32) as u32;
+        (x0 < x1 && y0 < y1).then_some((x0, y0, x1, y1))
+    }
+
+    /// Alpha-blend one pixel over the existing frame color.
+    fn blend_pixel(&mut self, x: u32, y: u32, r: u8, g: u8, b: u8, a: u8) {
+        let offset = self.offset(x, y);
+        let alpha = u16::from(a);
+        let inv_alpha = ALPHA_DENOMINATOR - alpha;
+        self.pixels[offset] = ((u16::from(r) * alpha + u16::from(self.pixels[offset]) * inv_alpha)
+            / ALPHA_DENOMINATOR) as u8;
+        self.pixels[offset + 1] = ((u16::from(g) * alpha
+            + u16::from(self.pixels[offset + 1]) * inv_alpha)
+            / ALPHA_DENOMINATOR) as u8;
+        self.pixels[offset + 2] = ((u16::from(b) * alpha
+            + u16::from(self.pixels[offset + 2]) * inv_alpha)
+            / ALPHA_DENOMINATOR) as u8;
+        self.pixels[offset + 3] = OPAQUE_ALPHA;
     }
 
     /// Convert the solid frame into the shared media frame type.

--- a/crates/betamax-core/src/tape/model.rs
+++ b/crates/betamax-core/src/tape/model.rs
@@ -134,6 +134,11 @@ pub enum Command {
     Copy(String),
     /// Write the tape-local clipboard into the PTY.
     Paste,
+    /// Set presentation text rendered on later media frames.
+    ///
+    /// Captions are not PTY input and do not participate in waits. An empty string clears the
+    /// active caption.
+    Caption(String),
     /// Parsed placeholder for VHS `Source`; execution is intentionally not implemented yet.
     Source(PathBuf),
     /// Capture an immediate PNG screenshot without changing the primary outputs.

--- a/crates/betamax-core/src/tape/parser.rs
+++ b/crates/betamax-core/src/tape/parser.rs
@@ -85,6 +85,11 @@ fn parse_tokens(line_number: usize, tokens: &[String], commands: &mut Vec<Comman
                 cursor += 1;
             }
             "Paste" => commands.push(Command::Paste),
+            "Caption" => {
+                let text = required_token(line_number, tokens, cursor, "caption text")?;
+                commands.push(Command::Caption(text.to_string()));
+                cursor += 1;
+            }
             "Type" => {
                 let text = required_token(line_number, tokens, cursor, "text to type")?;
                 commands.push(Command::Type {
@@ -386,6 +391,7 @@ fn is_command_token(token: &str) -> bool {
             | "Env"
             | "Copy"
             | "Paste"
+            | "Caption"
             | "Source"
             | "Screenshot"
             | "State"
@@ -511,12 +517,14 @@ mod tests {
 
     #[test]
     fn parses_copy_paste_and_modified_keys() {
-        let tape = Tape::parse(r#"Copy "hello" Paste Ctrl+Alt+C F5 Shift+Tab"#).unwrap();
+        let tape =
+            Tape::parse(r#"Copy "hello" Paste Caption "Ready" Ctrl+Alt+C F5 Shift+Tab"#).unwrap();
         assert_eq!(
             tape.commands,
             vec![
                 Command::Copy("hello".to_string()),
                 Command::Paste,
+                Command::Caption("Ready".to_string()),
                 Command::Key {
                     key: Key::Press {
                         key: KeyCode::Char('C'),
@@ -557,6 +565,22 @@ mod tests {
     fn rejects_settings_after_runtime_commands() {
         let err = Tape::parse("Type hi\nSet Width 800").unwrap_err();
         assert!(err.to_string().contains("before runtime tape commands"));
+    }
+
+    #[test]
+    fn keeps_caption_as_command_after_wait_without_pattern() {
+        let tape = Tape::parse(r#"Wait+Screen Caption "Loaded""#).unwrap();
+        assert_eq!(
+            tape.commands,
+            vec![
+                Command::Wait {
+                    target: WaitTarget::Screen,
+                    pattern: None,
+                    timeout: None,
+                },
+                Command::Caption("Loaded".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/docs/tape-reference.md
+++ b/docs/tape-reference.md
@@ -21,6 +21,7 @@ is requested. Install it with `brew install ffmpeg` on macOS or
 `sudo apt-get update && sudo apt-get install ffmpeg` on Debian/Ubuntu.
 
 An extensionless `Output` path is treated as a directory for numbered PNG frames.
+`Caption <text>` commands render presentation text onto visual outputs, but do not create files.
 
 ## Settings
 
@@ -173,6 +174,23 @@ affect final state. `Hide` is for recording visibility, not execution isolation.
 Resumes appending frames to animated outputs and immediately captures the current terminal frame.
 This avoids a visible gap after hidden setup work and is the usual way to reveal a prepared terminal
 state.
+
+### `Caption <text>`
+
+Sets a caption rendered onto later visual media frames. The text is one token, so quote captions
+that contain spaces. Use `Caption ""` to clear the active caption.
+
+Captions are presentation metadata only. They do not write to the PTY, alter terminal state, affect
+wait matching, or change output dimensions. Active captions appear on GIF, PNG, MP4, WebM, frame
+directory, and `Screenshot` outputs. `State` JSON does not include captions.
+
+`Caption` does not capture a frame or add time to animated output by itself. The new caption appears
+on the next visual frame Betamax renders, such as a frame captured during a later `Sleep`, `Wait`,
+typing, key press, `Show`, final-frame output, or `Screenshot`. Add `Sleep` after a caption-only
+change when an animation should dwell on the new caption without changing terminal content.
+
+Betamax renders captions as a bottom overlay. If the overlay covers important terminal content,
+increase the tape height, margin, or padding, or clear the caption before the affected frame.
 
 ### `Screenshot <path>.png`
 

--- a/examples/captions.tape
+++ b/examples/captions.tape
@@ -1,0 +1,27 @@
+Output examples/output/captions.gif
+Output examples/output/captions.png
+
+Require printf
+Require sleep
+
+Set Shell "bash"
+Set Theme "Catppuccin Mocha"
+Set FontSize 23
+Set Framerate 12
+Set Width 960
+Set Height 540
+Set Margin 12
+Set WindowBar Colorful
+Set BorderRadius 8
+
+Caption "Step 1: hidden setup produced this review frame"
+Hide
+Type "printf 'loading...\n'; sleep 2; printf 'checkpoint ready\n'"
+Enter
+Wait+Screen "checkpoint ready"
+Show
+Sleep 700ms
+
+Caption "Step 2: checkpoint output is visible"
+Screenshot examples/output/captions-checkpoint.png
+Sleep 900ms

--- a/site/public/assets/betamax-captions.gif
+++ b/site/public/assets/betamax-captions.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bf77b2415cd25506e5ad36742029ddbf1a1dd408ed739089ddf1b727e0563cb
+size 40609

--- a/site/src/content/docs/authoring/outputs.mdx
+++ b/site/src/content/docs/authoring/outputs.mdx
@@ -30,6 +30,10 @@ Use GIF for documentation and release notes. Use PNG screenshots when a human ne
 single stable state. Use state JSON when a test should compare text, scrollback, cursor metadata,
 and styles without doing pixel comparisons.
 
+Use [`Caption`](../../reference/tape-reference/#caption-text) when generated visual media should
+explain a workflow step or review checkpoint without changing terminal behavior. Captions render on
+visual outputs only; they do not appear in state JSON.
+
 Frame directories are useful when debugging capture timing or feeding rendered frames to custom
 tooling. The path must not have an extension; `Output target/frames` writes numbered PNG files under
 that directory.
@@ -75,3 +79,38 @@ State target/snapshots/ready.json
 The [`Screenshot`](../../reference/tape-reference/#screenshot-pathpng) preserves the decorated
 visual frame. The [`State`](../../reference/tape-reference/#state-pathjson) JSON preserves terminal
 text and styles in a compact comparison format.
+
+## Captions
+
+Captions annotate rendered media without changing the terminal session. They are useful when a GIF
+or screenshot needs to explain hidden setup, a review checkpoint, or a step in a TUI flow. Keep
+semantic checks in waits and state outputs; captions are presentation metadata.
+
+```text
+Caption "Step 1: prepare the review frame"
+Hide
+Type "my-app --demo"
+Enter
+Wait+Screen "Ready"
+Show
+Sleep 700ms
+
+Caption "Step 2: capture the ready state"
+Screenshot target/snapshots/ready.png
+State target/snapshots/ready.json
+
+Caption ""
+Sleep 300ms
+```
+
+The caption remains active until the next `Caption` command. Use `Caption ""` before later frames
+that should not have an overlay. Quote caption text that contains spaces.
+
+`Caption` has no duration and does not capture a frame by itself. It changes the caption used by
+the next rendered visual frame: animation frames captured during later `Sleep`, `Wait`, typing,
+keys, `Show`, or final-frame output, and checkpoint screenshots captured by `Screenshot`. If the
+terminal is already stable and only the caption changed, add `Sleep` after `Caption` so GIF and
+video outputs hold that caption for a visible amount of time.
+
+Captions render on visual outputs: GIF, PNG, MP4, WebM, frame directories, and screenshots. They do
+not appear in state JSON.

--- a/site/src/content/docs/examples.mdx
+++ b/site/src/content/docs/examples.mdx
@@ -12,7 +12,8 @@ mise run render-examples
 ```
 
 Generated files are written under `examples/output` and copied to `target/betamax-examples` for
-local inspection. README and site GIF previews are hosted as GitHub Release assets; see
+local inspection. README GIF previews are hosted as GitHub Release assets; curated site previews may
+also live under `site/public/assets` with Git LFS. See
 [Generated Media Storage](../authoring/generated-media/) for the full storage guidance.
 
 ## Example Index
@@ -25,6 +26,7 @@ local inspection. README and site GIF previews are hosted as GitHub Release asse
 | [`waits.tape`][waits-src]                 | line, screen, regex, and default prompt waits   | [Wait commands](../reference/tape-reference/#waitduration-regextext)   |
 | [`keys.tape`][keys-src]                   | key commands, repeats, editing, and interrupt   | [Key commands](../reference/tape-reference/#key-commands)              |
 | [`clipboard-env.tape`][clipboard-env-src] | `Env`, `Copy`, and `Paste`                      | [Tape reference](../reference/tape-reference/#copy-text-and-paste)     |
+| [`captions.tape`][captions-src]           | visual captions for review media                | [Caption command](../reference/tape-reference/#caption-text)           |
 | [`outputs.tape`][outputs-src]             | GIF, PNG, JSON, screenshot, state, frame dir    | [Outputs](../authoring/outputs/)                                       |
 | [`scrollback.tape`][scrollback-src]       | scrollback-inclusive state JSON                 | [State JSON](../testing/state-json/)                                   |
 | [`text-styles.tape`][text-styles-src]     | ANSI styles, truecolor, and styled state spans  | [State JSON](../testing/state-json/#styles-and-spans)                  |
@@ -58,6 +60,13 @@ one command, waits for the result, and hides shell cleanup.
 `hide-show.tape` demonstrates the most important authoring trick. Hidden setup still runs and
 updates terminal state, but the animation starts only when `Show` reveals the prepared screen.
 
+### Captions
+
+![Captioned Betamax GIF](/betamax/assets/betamax-captions.gif)
+
+`captions.tape` annotates rendered media without changing the terminal session. Caption changes are
+presentation metadata: waits and state outputs keep matching the terminal itself.
+
 ### Themes
 
 ![Ghostty theme Betamax GIF](https://github.com/joshka/betamax/releases/download/readme-assets/themes.gif)
@@ -86,6 +95,7 @@ Use `examples/waits.tape` when debugging timing. It shows the three wait targets
 `WaitPattern`, which is usually preferable to adding sleeps.
 
 [basic-src]: https://github.com/joshka/betamax/blob/main/examples/basic.tape
+[captions-src]: https://github.com/joshka/betamax/blob/main/examples/captions.tape
 [clipboard-env-src]: https://github.com/joshka/betamax/blob/main/examples/clipboard-env.tape
 [hide-show-src]: https://github.com/joshka/betamax/blob/main/examples/hide-show.tape
 [keys-src]: https://github.com/joshka/betamax/blob/main/examples/keys.tape

--- a/site/src/content/docs/reference/tape-reference.mdx
+++ b/site/src/content/docs/reference/tape-reference.mdx
@@ -21,7 +21,7 @@ errors fail before the PTY is spawned.
 - Startup commands must appear before runtime commands.
 
 Startup commands are `Output`, `Require`, `Set`, and `Env`. Runtime commands include typing, keys,
-waits, sleeps, screenshots, state checkpoints, `Hide`, `Show`, `Copy`, and `Paste`.
+waits, sleeps, captions, screenshots, state checkpoints, `Hide`, `Show`, `Copy`, and `Paste`.
 
 ## Outputs
 
@@ -159,6 +159,23 @@ or teardown that should not appear in the final GIF/video.
 
 Resumes frame capture and immediately captures the current terminal. This reveals the prepared
 state without showing the hidden commands that produced it.
+
+### `Caption <text>`
+
+Sets a caption rendered onto later visual media frames. The text is one token, so quote captions
+that contain spaces. Use `Caption ""` to clear the active caption.
+
+Captions are presentation metadata only. They do not write to the PTY, alter terminal state, affect
+wait matching, or change output dimensions. Active captions appear on GIF, PNG, MP4, WebM, frame
+directory, and `Screenshot` outputs. `State` JSON does not include captions.
+
+`Caption` does not capture a frame or add time to animated output by itself. The new caption appears
+on the next visual frame Betamax renders, such as a frame captured during a later `Sleep`, `Wait`,
+typing, key press, `Show`, final-frame output, or `Screenshot`. Add `Sleep` after a caption-only
+change when an animation should dwell on the new caption without changing terminal content.
+
+Betamax renders captions as a bottom overlay. If the overlay covers important terminal content,
+increase the tape height, margin, or padding, or clear the caption before the affected frame.
 
 ### `Screenshot <path>.png`
 


### PR DESCRIPTION
## Summary

- Add a `Caption "text"` tape command for presentation-only media annotations.
- Render active captions during final frame decoration so GIF, PNG, MP4, WebM, frame directory, and `Screenshot` outputs share the same overlay path.
- Keep captions out of PTY input, waits, terminal state, and `State` JSON.
- Document caption clearing with `Caption ""`, caption timing, and review-media authoring guidance.
- Add `examples/captions.tape` plus an LFS-backed docs preview GIF in `site/public/assets/betamax-captions.gif`.

## Preview

Generated from `cargo run -p betamax -- run --quiet examples/captions.tape`. This render includes the delayed hidden `sleep 2` before `checkpoint ready`, so `Wait+Screen "checkpoint ready"` waits for a real terminal change. The same LFS-backed GIF is referenced from the docs examples page.

![Captioned media preview](https://media.githubusercontent.com/media/joshka/betamax/97aacd92286b01d4e4a9fbd594dd16b435394d74/site/public/assets/betamax-captions.gif)

## Validation

Full validation run before publication:

- `mise run fmt`
- `mise run clippy`
- `mise run test`
- `mise run validate`

Docs validation after restoring the LFS-backed docs preview:

- `mise run lint-md`
- `mise run docs-site-check`
- `mise run docs-site-build`

Latest preview refresh after adding the delayed checkpoint output:

- `cargo run -p betamax -- run --quiet examples/captions.tape`

`mise run docs-site-build` still emits the existing Vite warnings for unresolved `/betamax/assets/...` URLs, then completes successfully.
