### PR TITLE
Document tape pacing guidance

### DIFF
--- a/docs/tape-reference.md
+++ b/docs/tape-reference.md
@@ -58,6 +58,11 @@ subtracted from width and height first, then padding, font size, letter spacing,
 determine the PTY columns and rows. Extremely small dimensions are clamped to at least one row and
 one column.
 
+Treat larger `FontSize`, larger `Margin`, and decorative frame settings as presentation zoom. When
+the tape is proving modal placement, centered content, wrapping, or split-pane layout, prefer the
+default `FontSize`, default `Margin`, and a wider `Width` or `Height` so the proof matches the
+application layout rather than the demo framing.
+
 For built-in shell names such as `bash`, `zsh`, and `fish`, Betamax starts a clean recording shell
 with startup files and history disabled where possible. Those shells use the VHS-style colored `>`
 prompt by default, so captures do not inherit prompts such as `bash-5.3$` from the host
@@ -115,6 +120,10 @@ capture frames during the sleep so animations show output that appears while wai
 Durations accept compact forms such as `500ms` and `1s`, as well as VHS-style forms such as `0.5`,
 `500 ms`, and `1 s`. Bare numeric durations are seconds.
 
+In validation tapes, use sleeps as a last resort for behavior that cannot be matched with a prompt,
+status line, or visible screen text. In example and review-media tapes, sleeps are presentation
+pacing after a semantic wait has already proved the screen state.
+
 ### `Type[@duration] <text>`
 
 Types Unicode text into the PTY one scalar value at a time. `Type@duration` overrides the default
@@ -138,6 +147,9 @@ and `Paste` writes nothing.
 
 Waits until terminal text matches a pattern while continuing to drain output and capture frames.
 Bare `Wait` inspects the current cursor line and uses `Set WaitPattern` as its pattern.
+
+Waits are assertions and synchronization points. Put `Wait`, `Wait+Line`, or `Wait+Screen` before
+any sleep that only exists to make a GIF, video, or review artifact readable.
 
 Pattern forms:
 

--- a/docs/terminal-testing.md
+++ b/docs/terminal-testing.md
@@ -5,6 +5,17 @@ wait for text on the screen, capture PNG screenshots at checkpoints, write struc
 state, and fail when expected terminal output does not appear before a timeout. That makes it useful
 for CLI and TUI smoke tests in the same broad role that Playwright fills for browser flows.
 
+Validation tapes and review-media tapes optimize for different readers. Validation tapes exercise a
+user journey, wait for semantic screen state, and write focused `State` or `Screenshot` checkpoints
+for assertions. Review-media tapes make the same kind of journey readable for humans in a GIF,
+video, screenshot, or pull-request artifact.
+
+Waits are assertions and synchronization points. In validation tapes, put a semantic `Wait`,
+`Wait+Line`, or `Wait+Screen` after each meaningful app transition, then add `Sleep` only when the
+generated media needs human pacing or no semantic wait is possible. Useful review-media pauses are
+300-700 ms after simple transitions, 1.5-2.5 seconds for stable simple screens, and 4-5 seconds
+only for final review endpoints.
+
 For test-oriented tapes, prefer:
 
 - `Require` for external programs the test depends on.

--- a/site/src/content/docs/authoring/outputs.mdx
+++ b/site/src/content/docs/authoring/outputs.mdx
@@ -34,6 +34,28 @@ Frame directories are useful when debugging capture timing or feeding rendered f
 tooling. The path must not have an extension; `Output target/frames` writes numbered PNG files under
 that directory.
 
+## Validation And Review Artifacts
+
+Validation artifacts should be easy to assert automatically. Prefer `State` checkpoints or final
+state JSON for the behavioral contract, and add checkpoint screenshots when the visual frame helps
+debug failures.
+
+Review-media artifacts should be easy for a human to inspect. Pair animated GIF or video output
+with a final PNG or a checkpoint screenshot whose path describes the state, so reviewers can cite
+one stable frame without scrubbing an animation. Place checkpoint outputs immediately after a
+semantic wait:
+
+```text
+Wait+Screen "Profile saved"
+State target/snapshots/profile-saved.json
+Screenshot target/review/profile-saved.png
+Sleep 2s
+```
+
+In review media, sleeps after waits are presentation pacing. Use 300-700 ms after simple
+transitions, 1.5-2.5 seconds for stable simple screens, and 4-5 seconds only for final review
+endpoints. Dense output needs a reading-time-based hold instead of a fixed one-size pause.
+
 ## Video Encoding
 
 MP4 and WebM use `ffmpeg` as a focused encoder boundary. Terminal execution, terminal parsing,

--- a/site/src/content/docs/authoring/tape-files.mdx
+++ b/site/src/content/docs/authoring/tape-files.mdx
@@ -121,6 +121,71 @@ Wait+Screen "test result:"
 </aside>
 </section>
 
+<section class="bm-manual-row bm-manual-row-top" aria-labelledby="validation-and-review-media">
+<div class="bm-manual-copy">
+
+## Validation And Review Media
+
+Most tapes have one primary job. Validation tapes exercise a user journey, wait for semantic
+screen state, and write focused `State` or `Screenshot` checkpoints for assertions. Example and
+review-media tapes make a stable state readable for humans in a GIF, video, or PR artifact.
+
+Waits are assertions and synchronization points. Use `Wait`, `Wait+Line`, or `Wait+Screen` to name
+the state that must exist before the tape continues. Sleeps are presentation pacing after that
+state is true, unless the application has no semantic text or prompt that Betamax can wait for.
+
+</div>
+
+<div class="bm-manual-code">
+
+```text
+Type "my-app --demo"
+Enter
+Wait+Screen "Ready"
+Screenshot target/review/ready.png
+Sleep 500ms
+```
+
+</div>
+
+<aside class="bm-manual-note">
+  <p class="bm-note-label">Pacing</p>
+  <ul>
+    <li>Use 300-500 ms before submission when a GIF should feel human.</li>
+    <li>Use 300-700 ms after simple UI transitions.</li>
+    <li>Use 1.5-2.5 seconds for stable simple screens.</li>
+    <li>Use reading-time-based holds for dense output.</li>
+    <li>Use 4-5 seconds only for final GIF states or equivalent review endpoints.</li>
+  </ul>
+</aside>
+</section>
+
+<section class="bm-manual-row bm-manual-row-split" aria-labelledby="presentation-and-layout-proof">
+<div class="bm-manual-copy">
+
+## Presentation And Layout Proof
+
+Larger `FontSize`, `Margin`, window bars, and border radius are presentation choices. They make a
+demo easier to read, but they also change the terminal grid and available layout space.
+
+When a tape proves modal placement, centering, wrapping, or split-pane behavior, start with the
+default `FontSize` and `Margin`. Increase `Width` and `Height` when the proof needs a wider canvas.
+Use a separate review-media tape when the same journey also needs zoomed presentation.
+
+</div>
+
+<div class="bm-manual-code bm-compact-code">
+
+```text
+Set Width 1600
+Set Height 900
+Wait+Screen "Preview"
+Screenshot target/layout/proof.png
+```
+
+</div>
+</section>
+
 <section class="bm-manual-row bm-manual-row-split" aria-labelledby="hidden-work">
 <div class="bm-manual-copy">
 

--- a/site/src/content/docs/authoring/themes.mdx
+++ b/site/src/content/docs/authoring/themes.mdx
@@ -47,6 +47,10 @@ These settings affect the final output frame and PTY grid:
 Betamax derives PTY columns and rows from these values. Increasing padding or font size usually
 reduces the terminal grid size; increasing width or height usually increases it.
 
+Treat larger font size, padding, margins, window bars, and border radius as presentation choices.
+For layout proof captures, prefer default `FontSize` and `Margin` with a wider canvas; see
+[Presentation And Layout Proof](../tape-files/#presentation-and-layout-proof).
+
 ## Frame Decoration
 
 These settings are applied after the raw terminal frame is rendered:

--- a/site/src/content/docs/reference/tape-reference.mdx
+++ b/site/src/content/docs/reference/tape-reference.mdx
@@ -75,6 +75,11 @@ subtracted from width and height first, then padding, font size, letter spacing,
 determine the PTY columns and rows. Extremely small dimensions are clamped to at least one row and
 one column.
 
+Treat larger `FontSize`, larger `Margin`, and decorative frame settings as presentation zoom. When
+the tape is proving modal placement, centered content, wrapping, or split-pane layout, prefer the
+default `FontSize`, default `Margin`, and a wider `Width` or `Height` so the proof matches the
+application layout rather than the demo framing.
+
 ## Command Reference
 
 ### `Output <path>`
@@ -131,11 +136,18 @@ Pauses tape execution while continuing to drain PTY output and capture frames. D
 compact forms such as `500ms`, `1s`, and `2m`, split forms such as `500 ms`, and bare numbers as
 seconds.
 
+In validation tapes, use sleeps as a last resort for behavior that cannot be matched with a prompt,
+status line, or visible screen text. In example and review-media tapes, sleeps are presentation
+pacing after a semantic wait has already proved the screen state.
+
 ### `Wait[@duration] [/regex/|text]`
 
 Waits for terminal text while continuing to drain output and capture frames. A bare `Wait` checks
 the current cursor line with `WaitPattern`, which defaults to the VHS-style prompt regex `>$`.
 `Wait@5s` overrides the timeout for that command.
+
+Waits are assertions and synchronization points. Put `Wait`, `Wait+Line`, or `Wait+Screen` before
+any sleep that only exists to make a GIF, video, or review artifact readable.
 
 Use `/.../` for regex patterns and plain text for substring patterns.
 

--- a/site/src/content/docs/testing/terminal-testing.mdx
+++ b/site/src/content/docs/testing/terminal-testing.mdx
@@ -60,6 +60,24 @@ Env BETAMAX_TEST 1
 
 Use `Set CursorBlink false` when animation frame differences do not matter to the test.
 
+## Wait Before Sleep
+
+Validation tapes should synchronize on behavior before they add presentation pacing. Put a semantic
+`Wait`, `Wait+Line`, or `Wait+Screen` after every meaningful app transition, then add `Sleep` only
+when the generated media needs a human-readable pause.
+
+```text
+Type "my-tui --scripted"
+Enter
+Wait+Screen "Loaded 12 rows"
+State target/snapshots/loaded.json
+Sleep 500ms
+```
+
+Keep validation sleeps short and rare. If a sleep is compensating for behavior that cannot be
+matched with visible text, a prompt, or a status line, keep it as small as the program allows and
+leave a tape comment explaining what external effect it covers.
+
 ## Snapshot Workflow
 
 A common Rust test shape is:


### PR DESCRIPTION
## Summary

- Document validation tapes versus example and review-media tapes.
- Clarify that waits are assertions and synchronization points, while sleeps are presentation pacing unless no semantic wait is possible.
- Add practical human pacing ranges and layout-proof guidance for default font/margin with wider canvases.

## Validation

- `mise run lint-md`
- `mise run docs-site-check`
- `mise run docs-site-build`
- `mise exec -- cargo run -p betamax -- run examples/outputs.tape`

The generated example media was used for local proof and remains untracked.
