### PR TITLE
Add keyboard overlay rendering

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 site/public/assets/betamax-hero-terminal.png filter=lfs diff=lfs merge=lfs -text
 site/public/assets/betamax-hero-quick-start.gif filter=lfs diff=lfs merge=lfs -text
 site/public/assets/betamax-captions.gif filter=lfs diff=lfs merge=lfs -text
+site/public/assets/betamax-keyboard-overlay.gif filter=lfs diff=lfs merge=lfs -text
+site/public/assets/betamax-keyboard-overlay.png filter=lfs diff=lfs merge=lfs -text

--- a/crates/betamax-core/src/runner/capture.rs
+++ b/crates/betamax-core/src/runner/capture.rs
@@ -7,6 +7,9 @@ use crate::media::Frame;
 use crate::runner::TerminalSession;
 use crate::Result;
 
+/// How long a keyboard overlay label remains visible after being queued.
+const KEYBOARD_OVERLAY_LINGER: Duration = Duration::from_millis(1500);
+
 /// Mutable frame-collection state for one captured run.
 ///
 /// Visibility is a recording concern, not a terminal-state concern. Hidden commands still mutate
@@ -28,6 +31,8 @@ pub(super) struct CaptureState {
     /// This is presentation metadata only. It does not affect PTY execution, terminal state, or
     /// semantic wait matching.
     pub(super) caption: Option<String>,
+    /// Keyboard overlay labels that are currently visible.
+    keyboard_overlay_events: Vec<KeyboardOverlayEvent>,
 }
 
 impl Default for CaptureState {
@@ -36,6 +41,7 @@ impl Default for CaptureState {
             visible: true,
             frames: Vec::new(),
             caption: None,
+            keyboard_overlay_events: Vec::new(),
         }
     }
 }
@@ -43,10 +49,29 @@ impl Default for CaptureState {
 /// Raw captured terminal frame plus presentation metadata for final media decoration.
 #[derive(Debug, Clone)]
 pub(super) struct CapturedFrame {
-    /// Raw terminal frame before final margin/window/caption decoration.
+    /// Raw terminal frame before final margin/window/caption/overlay decoration.
     pub(super) frame: Frame,
     /// Caption active when this frame was captured.
     pub(super) caption: Option<String>,
+    /// Keyboard overlay labels visible when this frame was captured.
+    pub(super) keyboard_overlay_labels: Vec<String>,
+}
+
+/// One keyboard overlay event that is currently visible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct KeyboardOverlayEvent {
+    /// Label drawn in the overlay HUD.
+    label: String,
+    /// Remaining visible time for this label.
+    remaining: Duration,
+}
+
+/// Queue a keyboard overlay label for the next captured frames.
+pub(super) fn queue_keyboard_overlay_label(capture: &mut CaptureState, label: String) {
+    capture.keyboard_overlay_events.push(KeyboardOverlayEvent {
+        label,
+        remaining: KEYBOARD_OVERLAY_LINGER,
+    });
 }
 
 /// Capture one raw terminal frame with runner-controlled cursor blinking.
@@ -63,25 +88,39 @@ pub(super) fn capture_frame(
     terminal.capture_frame_with_cursor(cursor_visible)
 }
 
-/// Append one visible frame or extend the previous frame when pixels and caption have not changed.
+/// Append one visible frame or extend the previous frame when pixels and metadata have not changed.
 ///
 /// This preserves wall-clock dwell time for static terminal states. Without delay coalescing, a
 /// `Sleep 2s` after the final output only contributes as many nominal frame delays as the renderer
 /// can sample during those two seconds, which can make GIFs play much faster than the tape timing.
 ///
-/// Captions are included in the coalescing key even though they are not terminal pixels yet. A
-/// repeated terminal frame with a new caption is a visible media change after final decoration.
+/// Presentation metadata is included in the coalescing key even though it is not terminal pixels
+/// yet. A repeated terminal frame with a new caption or keyboard overlay is a visible media change
+/// after final decoration. Active keyboard overlays intentionally avoid coalescing so their linger
+/// timers can age across recorded frame time.
 pub(super) fn append_visible_frame(capture: &mut CaptureState, frame: Frame, delay: Duration) {
     let caption = capture.caption.clone();
+    let keyboard_overlay_labels = active_keyboard_overlay_labels(capture);
     if let Some((last_frame, last_delay)) = capture.frames.last_mut() {
-        if last_frame.caption == caption && frames_equal(&last_frame.frame, &frame) {
+        if frames_equal(&last_frame.frame, &frame)
+            && last_frame.caption == caption
+            && last_frame.keyboard_overlay_labels == keyboard_overlay_labels
+            && keyboard_overlay_labels.is_empty()
+        {
             *last_delay += delay;
+            age_keyboard_overlay_labels(capture, delay);
             return;
         }
     }
-    capture
-        .frames
-        .push((CapturedFrame { frame, caption }, delay));
+    capture.frames.push((
+        CapturedFrame {
+            frame,
+            caption,
+            keyboard_overlay_labels,
+        },
+        delay,
+    ));
+    age_keyboard_overlay_labels(capture, delay);
 }
 
 /// Append the final still frame for animated outputs when it differs from the last visible frame.
@@ -97,10 +136,30 @@ pub(super) fn append_final_gif_frame(capture: &mut CaptureState, frame: Frame, d
             CapturedFrame {
                 frame,
                 caption: capture.caption.clone(),
+                keyboard_overlay_labels: active_keyboard_overlay_labels(capture),
             },
             delay,
         ));
     }
+}
+
+/// Return active keyboard overlay labels in queue order.
+pub(super) fn active_keyboard_overlay_labels(capture: &CaptureState) -> Vec<String> {
+    capture
+        .keyboard_overlay_events
+        .iter()
+        .map(|event| event.label.clone())
+        .collect()
+}
+
+/// Age active keyboard overlay labels by recorded frame time.
+fn age_keyboard_overlay_labels(capture: &mut CaptureState, delay: Duration) {
+    for event in &mut capture.keyboard_overlay_events {
+        event.remaining = event.remaining.saturating_sub(delay);
+    }
+    capture
+        .keyboard_overlay_events
+        .retain(|event| !event.remaining.is_zero());
 }
 
 /// Compare frames byte-for-byte.

--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -49,7 +49,10 @@ mod settings;
 
 #[doc(inline)]
 pub use artifacts::RunArtifacts;
-use capture::{append_final_gif_frame, append_visible_frame, capture_frame, CaptureState};
+use capture::{
+    active_keyboard_overlay_labels, append_final_gif_frame, append_visible_frame, capture_frame,
+    queue_keyboard_overlay_label, CaptureState,
+};
 #[doc(inline)]
 pub use options::RunOptions;
 use pty::PtySession;
@@ -419,8 +422,11 @@ where
             );
             settings.apply_loop_offset(&mut capture.frames);
         }
-        let frame =
-            settings.decorate_frame_with_caption(&final_raw_frame, capture.caption.as_deref())?;
+        let frame = settings.decorate_frame_with_overlays(
+            &final_raw_frame,
+            capture.caption.as_deref(),
+            &active_keyboard_overlay_labels(&capture),
+        )?;
         let media_frames = decorate_captured_frames(&settings, &mut capture)?;
 
         let output_paths = outputs.paths();
@@ -508,6 +514,11 @@ where
             kind = command_kind(command),
             "running captured tape command"
         );
+        if capture.visible {
+            if let Some(label) = settings.keyboard_overlay_label(command) {
+                queue_keyboard_overlay_label(capture, label);
+            }
+        }
         match command {
             Command::Sleep(duration) => {
                 session.drain_for(terminal, *duration, settings, capture)?;
@@ -562,9 +573,10 @@ where
                 session.drain_into(terminal, CHECKPOINT_IDLE)?;
                 write_png(
                     path,
-                    &settings.decorate_frame_with_caption(
+                    &settings.decorate_frame_with_overlays(
                         &capture_frame(terminal, settings, capture.frames.len())?,
                         capture.caption.as_deref(),
+                        &active_keyboard_overlay_labels(capture),
                     )?,
                 )?;
             }
@@ -710,12 +722,7 @@ fn decorate_captured_frames(
     settings: &Settings,
     capture: &mut CaptureState,
 ) -> Result<Vec<(Frame, Duration)>> {
-    settings.decorate_captioned_frames(
-        capture
-            .frames
-            .drain(..)
-            .map(|(captured, delay)| (captured.frame, captured.caption, delay)),
-    )
+    settings.decorate_captured_frames(capture.frames.drain(..))
 }
 
 /// Convert parsed caption text into the active presentation state.
@@ -885,6 +892,7 @@ fn describe_text(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::settings::KeyboardOverlayMode;
     use super::*;
     use crate::media::Frame;
     use crate::runner::capture::{frames_equal, CapturedFrame};
@@ -910,6 +918,7 @@ mod tests {
         assert_eq!(settings.style.window_bar_size, 30);
         assert_eq!(settings.style.window_bar_color, "#102040");
         assert_eq!(settings.style.border_radius, 0);
+        assert_eq!(settings.keyboard_overlay.mode, KeyboardOverlayMode::Off);
     }
 
     #[test]
@@ -940,6 +949,148 @@ mod tests {
         assert_eq!(settings.style.window_bar, "Colorful");
         assert_eq!(settings.style.window_bar_size, 40);
         assert_eq!(settings.style.border_radius, 8);
+    }
+
+    #[test]
+    fn keyboard_overlay_keys_mode_shows_only_key_commands() {
+        let tape = Tape::parse(
+            r#"
+            Set KeyboardOverlay Keys
+            Type "open palette"
+            Ctrl+P
+            Down 2
+            Enter
+            Copy "from clipboard"
+            Paste
+            "#,
+        )
+        .unwrap();
+
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(settings.keyboard_overlay.mode, KeyboardOverlayMode::Keys);
+        assert_eq!(
+            tape.commands
+                .iter()
+                .filter_map(|command| settings.keyboard_overlay_label(command))
+                .collect::<Vec<_>>(),
+            vec!["Ctrl+P", "Down x2", "Enter"]
+        );
+    }
+
+    #[test]
+    fn keyboard_overlay_input_mode_shows_short_typed_intent() {
+        let tape = Tape::parse(
+            r#"
+            Set KeyboardOverlay Input
+            Type "echo foo"
+            Type "printf 'too implementation-shaped\n'"
+            Ctrl+P
+            Paste
+            "#,
+        )
+        .unwrap();
+
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(settings.keyboard_overlay.mode, KeyboardOverlayMode::Input);
+        assert_eq!(
+            tape.commands
+                .iter()
+                .filter_map(|command| settings.keyboard_overlay_label(command))
+                .collect::<Vec<_>>(),
+            vec!["Type \"echo foo\"", "Ctrl+P", "Paste"]
+        );
+    }
+
+    #[test]
+    fn keyboard_overlay_all_mode_summarizes_every_visible_input() {
+        let tape = Tape::parse(
+            r#"
+            Set KeyboardOverlay All
+            Type "echo foo"
+            Type "printf 'implementation-shaped but visible\n'"
+            Ctrl+P
+            Paste
+            "#,
+        )
+        .unwrap();
+
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(settings.keyboard_overlay.mode, KeyboardOverlayMode::All);
+        assert_eq!(
+            tape.commands
+                .iter()
+                .filter_map(|command| settings.keyboard_overlay_label(command))
+                .collect::<Vec<_>>(),
+            vec!["Type \"echo foo\"", "Type 44 chars", "Ctrl+P", "Paste",]
+        );
+    }
+
+    #[test]
+    fn keyboard_overlay_labels_hidden_input_only_at_runtime() {
+        let tape = Tape::parse(
+            r#"
+            Set KeyboardOverlay Input
+            Type "visible"
+            Hide
+            Type "secret"
+            Enter
+            Show
+            Down
+            "#,
+        )
+        .unwrap();
+
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(
+            tape.commands
+                .iter()
+                .filter_map(|command| settings.keyboard_overlay_label(command))
+                .collect::<Vec<_>>(),
+            vec!["Type \"visible\"", "Type \"secret\"", "Enter", "Down"]
+        );
+    }
+
+    #[test]
+    fn keyboard_overlay_changes_pixels_without_resizing_output() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 80
+            Set Height 40
+            Set Padding 0
+            Set KeyboardOverlay Input
+            Type "abc"
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+        let frame = sized_test_frame(
+            settings.terminal_canvas_width(),
+            settings.terminal_canvas_height(),
+            [255, 0, 0, 255],
+        );
+
+        let labels = vec!["Type \"abc\"".to_string()];
+        let decorated = settings
+            .decorate_frame_with_overlays(&frame, None, &labels)
+            .unwrap();
+        let rgba = decorated.rgba().unwrap();
+        let bottom_left = rgba_pixel(&rgba, decorated.width, 1, decorated.height - 1);
+
+        assert_eq!(decorated.width, 80);
+        assert_eq!(decorated.height, 40);
+        assert_ne!(bottom_left, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn invalid_keyboard_overlay_modes_are_errors() {
+        let tape = Tape::parse("Set KeyboardOverlay floating").unwrap();
+        let error = Settings::from_tape(&tape).unwrap_err().to_string();
+
+        assert!(error.contains("Set KeyboardOverlay expects Off, Keys, Input, or All"));
     }
 
     #[test]
@@ -999,7 +1150,9 @@ mod tests {
             [255, 0, 0, 255],
         );
 
-        let decorated = settings.decorate_frame_with_caption(&frame, None).unwrap();
+        let decorated = settings
+            .decorate_frame_with_overlays(&frame, None, &[])
+            .unwrap();
 
         assert_eq!(decorated.width, 10);
         assert_eq!(decorated.height, 8);
@@ -1022,9 +1175,11 @@ mod tests {
             [255, 0, 0, 255],
         );
 
-        let plain = settings.decorate_frame_with_caption(&frame, None).unwrap();
+        let plain = settings
+            .decorate_frame_with_overlays(&frame, None, &[])
+            .unwrap();
         let captioned = settings
-            .decorate_frame_with_caption(&frame, Some("Review checkpoint"))
+            .decorate_frame_with_overlays(&frame, Some("Review checkpoint"), &[])
             .unwrap();
 
         assert_eq!(captioned.width, plain.width);
@@ -1068,17 +1223,16 @@ mod tests {
     fn trailing_hide_keeps_cleanup_frame_out_of_gif() {
         let visible_frame = test_frame([255, 0, 0, 255]);
         let cleanup_frame = test_frame([0, 255, 0, 255]);
-        let mut capture = CaptureState {
-            visible: false,
-            frames: vec![(
-                CapturedFrame {
-                    frame: visible_frame.clone(),
-                    caption: None,
-                },
-                Duration::from_millis(20),
-            )],
-            caption: None,
-        };
+        let mut capture = CaptureState::default();
+        capture.visible = false;
+        capture.frames.push((
+            CapturedFrame {
+                frame: visible_frame.clone(),
+                caption: None,
+                keyboard_overlay_labels: Vec::new(),
+            },
+            Duration::from_millis(20),
+        ));
 
         append_final_gif_frame(&mut capture, cleanup_frame, Duration::from_millis(20));
 
@@ -1107,6 +1261,24 @@ mod tests {
         assert_eq!(active_caption("  Step 1  ").as_deref(), Some("  Step 1  "));
     }
 
+    #[test]
+    fn keyboard_overlay_lingers_then_expires() {
+        let frame = test_frame([255, 0, 0, 255]);
+        let mut capture = CaptureState::default();
+
+        queue_keyboard_overlay_label(&mut capture, "Enter".to_string());
+        append_visible_frame(&mut capture, frame.clone(), Duration::from_millis(500));
+        append_visible_frame(&mut capture, frame.clone(), Duration::from_millis(500));
+        append_visible_frame(&mut capture, frame.clone(), Duration::from_millis(600));
+        append_visible_frame(&mut capture, frame, Duration::from_millis(20));
+
+        assert_eq!(capture.frames.len(), 4);
+        assert_eq!(capture.frames[0].0.keyboard_overlay_labels, vec!["Enter"]);
+        assert_eq!(capture.frames[1].0.keyboard_overlay_labels, vec!["Enter"]);
+        assert_eq!(capture.frames[2].0.keyboard_overlay_labels, vec!["Enter"]);
+        assert!(capture.frames[3].0.keyboard_overlay_labels.is_empty());
+    }
+
     fn test_frame(pixel: [u8; 4]) -> Frame {
         sized_test_frame(1, 1, pixel)
     }
@@ -1120,5 +1292,15 @@ mod tests {
             format: crate::media::PixelFormat::Rgba8,
             pixels: pixel.repeat(pixel_count),
         }
+    }
+
+    fn rgba_pixel(rgba: &[u8], width: u32, x: u32, y: u32) -> [u8; 4] {
+        let offset = ((y as usize * width as usize) + x as usize) * 4;
+        [
+            rgba[offset],
+            rgba[offset + 1],
+            rgba[offset + 2],
+            rgba[offset + 3],
+        ]
     }
 }

--- a/crates/betamax-core/src/runner/settings.rs
+++ b/crates/betamax-core/src/runner/settings.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 
 use crate::ghostty::{TerminalTheme, TextSettings};
 use crate::media::{Frame, PixelFormat};
-use crate::tape::{Command, Tape, Value, WaitPattern};
+use crate::tape::{Command, Key, KeyCode, Tape, Value, WaitPattern};
 use crate::wait::regex_source;
 use crate::Result;
 
@@ -75,6 +75,32 @@ const CAPTION_VERTICAL_PADDING: f32 = 0.45;
 const CAPTION_BACKGROUND_ALPHA: u8 = 0xdd;
 /// Denominator for 8-bit alpha blending.
 const ALPHA_DENOMINATOR: u16 = 255;
+/// Maximum number of recent overlay events drawn over the output frame.
+const KEYBOARD_OVERLAY_MAX_CHIPS: usize = 5;
+/// Maximum number of overlay rows drawn over the output frame.
+const KEYBOARD_OVERLAY_MAX_ROWS: usize = 2;
+/// Font size used by the compact keyboard overlay.
+const KEYBOARD_OVERLAY_FONT_SIZE: f32 = 18.0;
+/// Line height used by the compact keyboard overlay.
+const KEYBOARD_OVERLAY_LINE_HEIGHT: f32 = 25.0;
+/// Approximate label glyph width for row wrapping.
+const KEYBOARD_OVERLAY_CHAR_WIDTH: u32 = 12;
+/// Horizontal inset around the overlay HUD.
+const KEYBOARD_OVERLAY_INSET_X: u32 = 14;
+/// Vertical inset around the overlay HUD.
+const KEYBOARD_OVERLAY_INSET_Y: u32 = 12;
+/// Horizontal padding inside one key chip.
+const KEYBOARD_OVERLAY_CHIP_PAD_X: u32 = 10;
+/// Vertical padding inside one key chip.
+const KEYBOARD_OVERLAY_CHIP_PAD_Y: u32 = 4;
+/// Gap between key chips.
+const KEYBOARD_OVERLAY_CHIP_GAP: u32 = 8;
+/// Maximum number of displayed characters from one `Type` command.
+const KEYBOARD_OVERLAY_TYPE_MAX_CHARS: usize = 26;
+/// Alpha used for the overlay HUD.
+const KEYBOARD_OVERLAY_PANEL_ALPHA: u8 = 210;
+/// Alpha used for individual key chips.
+const KEYBOARD_OVERLAY_CHIP_ALPHA: u8 = 235;
 
 /// Shell command and all derived execution, rendering, timing, and styling settings.
 ///
@@ -110,6 +136,8 @@ pub(super) struct Settings {
     pub(super) theme: TerminalTheme,
     /// Outer frame decoration settings.
     pub(super) style: StyleSettings,
+    /// Optional input-sequence overlay for review media.
+    pub(super) keyboard_overlay: KeyboardOverlaySettings,
     /// Whether captured frames should blink the cursor according to the output framerate.
     pub(super) cursor_blink: bool,
     /// Default wait pattern used when a wait command does not provide one.
@@ -139,6 +167,37 @@ pub(super) struct StyleSettings {
     pub(super) window_bar_color: String,
     /// Radius for masking the captured terminal plus window bar.
     pub(super) border_radius: u32,
+}
+
+/// Presentation-only input labels drawn over generated media.
+///
+/// The labels are derived from tape commands and are never fed back into PTY execution. This keeps
+/// review media decoration separate from validation semantics and terminal sizing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct KeyboardOverlaySettings {
+    /// Which input commands are eligible for the overlay.
+    pub(super) mode: KeyboardOverlayMode,
+}
+
+impl KeyboardOverlaySettings {
+    /// Return whether a frame should draw the overlay.
+    fn visible(&self, labels: &[String]) -> bool {
+        self.mode != KeyboardOverlayMode::Off && !labels.is_empty()
+    }
+}
+
+/// Input event filtering used by the keyboard overlay.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum KeyboardOverlayMode {
+    /// Do not draw any keyboard overlay.
+    #[default]
+    Off,
+    /// Draw only explicit key commands such as `Ctrl+P`, arrows, `Enter`, and `Escape`.
+    Keys,
+    /// Draw key commands and short typed input that reads like user intent.
+    Input,
+    /// Draw every visible input event, including long `Type` commands summarized for space.
+    All,
 }
 
 impl StyleSettings {
@@ -184,6 +243,7 @@ impl Settings {
             typing_delay: DEFAULT_TYPING_DELAY,
             text: TextSettings::default(),
             style: StyleSettings::new(&theme),
+            keyboard_overlay: KeyboardOverlaySettings::default(),
             theme,
             cursor_blink: true,
             wait_pattern: WaitPattern::Regex(DEFAULT_WAIT_PATTERN.to_string()),
@@ -249,6 +309,9 @@ impl Settings {
                 self.style.border_radius = *border_radius as u32;
             }
             ("CursorBlink", Value::Bool(cursor_blink)) => self.cursor_blink = *cursor_blink,
+            ("KeyboardOverlay", Value::String(mode)) => {
+                self.keyboard_overlay.mode = parse_keyboard_overlay_mode(mode)?;
+            }
             ("WaitTimeout", Value::Duration(wait_timeout)) => self.wait_timeout = *wait_timeout,
             ("WaitTimeout", Value::Number(wait_timeout)) => {
                 self.wait_timeout = Duration::from_secs_f64(*wait_timeout);
@@ -383,17 +446,20 @@ impl Settings {
         frames.rotate_left(offset % len);
     }
 
-    /// Decorate a single raw terminal frame and optionally render a caption overlay.
-    ///
-    /// Captions are presentation metadata. They are applied after the terminal has rendered, using
-    /// the final output dimensions, and therefore do not affect PTY size, terminal state, or waits.
-    pub(super) fn decorate_frame_with_caption(
+    /// Decorate a single raw terminal frame with caption text and keyboard labels.
+    pub(super) fn decorate_frame_with_overlays(
         &self,
         frame: &Frame,
         caption: Option<&str>,
+        keyboard_overlay_labels: &[String],
     ) -> Result<Frame> {
         let mut caption_renderer = CaptionRenderer::new();
-        self.decorate_frame_with_caption_renderer(frame, caption, &mut caption_renderer)
+        self.decorate_frame_with_overlay_renderer(
+            frame,
+            caption,
+            keyboard_overlay_labels,
+            &mut caption_renderer,
+        )
     }
 
     /// Decorate captured frames with one reusable caption renderer.
@@ -401,17 +467,18 @@ impl Settings {
     /// Animated outputs may render hundreds of frames with the same caption text and font. Keeping
     /// one renderer here preserves the shaping and glyph caches for the batch without making cache
     /// lifetime part of `Settings`.
-    pub(super) fn decorate_captioned_frames(
+    pub(super) fn decorate_captured_frames(
         &self,
-        frames: impl IntoIterator<Item = (Frame, Option<String>, Duration)>,
+        frames: impl IntoIterator<Item = (super::capture::CapturedFrame, Duration)>,
     ) -> Result<Vec<(Frame, Duration)>> {
         let mut caption_renderer = CaptionRenderer::new();
         let mut decorated = Vec::new();
-        for (frame, caption, delay) in frames {
+        for (captured, delay) in frames {
             decorated.push((
-                self.decorate_frame_with_caption_renderer(
-                    &frame,
-                    caption.as_deref(),
+                self.decorate_frame_with_overlay_renderer(
+                    &captured.frame,
+                    captured.caption.as_deref(),
+                    &captured.keyboard_overlay_labels,
                     &mut caption_renderer,
                 )?,
                 delay,
@@ -425,10 +492,11 @@ impl Settings {
     /// Decoration happens in final output coordinates: margin, window bar, rounded mask, then
     /// caption overlay. Keeping captions last makes them independent from terminal canvas sizing
     /// and guarantees the same overlay path for final PNGs, screenshots, GIFs, and videos.
-    fn decorate_frame_with_caption_renderer(
+    fn decorate_frame_with_overlay_renderer(
         &self,
         frame: &Frame,
         caption: Option<&str>,
+        keyboard_overlay_labels: &[String],
         caption_renderer: &mut CaptionRenderer,
     ) -> Result<Frame> {
         let margin = self.effective_margin();
@@ -458,6 +526,9 @@ impl Settings {
         }
         if let Some(caption) = caption.filter(|caption| !caption.trim().is_empty()) {
             self.draw_caption(&mut output, caption, caption_renderer);
+        }
+        if self.keyboard_overlay.visible(keyboard_overlay_labels) {
+            output.draw_keyboard_overlay(keyboard_overlay_labels, &self.text);
         }
         Ok(output.into_frame())
     }
@@ -524,6 +595,11 @@ impl Settings {
             font_size,
             line_height,
         })
+    }
+
+    /// Return the keyboard overlay label for a visible input command, if enabled.
+    pub(super) fn keyboard_overlay_label(&self, command: &Command) -> Option<String> {
+        keyboard_overlay_label(command, self.keyboard_overlay.mode)
     }
 }
 
@@ -723,6 +799,68 @@ impl SolidFrame {
         }
     }
 
+    /// Draw the configured input sequence as compact key chips over the bottom of the frame.
+    fn draw_keyboard_overlay(&mut self, labels: &[String], text_settings: &TextSettings) {
+        let labels = recent_keyboard_overlay_labels(labels);
+        let rows = keyboard_overlay_rows(&labels, self.width);
+        if rows.is_empty() {
+            return;
+        }
+
+        let row_height = KEYBOARD_OVERLAY_LINE_HEIGHT.ceil() as u32;
+        let row_width = rows
+            .iter()
+            .map(|row| keyboard_overlay_row_width(row))
+            .max()
+            .unwrap_or(0);
+        let panel_width = row_width
+            .saturating_add(KEYBOARD_OVERLAY_INSET_X.saturating_mul(2))
+            .min(self.width);
+        let panel_height = KEYBOARD_OVERLAY_INSET_Y
+            .saturating_mul(2)
+            .saturating_add(row_height.saturating_mul(rows.len() as u32))
+            .min(self.height);
+        let panel_x = self.width.saturating_sub(panel_width) / 2;
+        let panel_y = self.height.saturating_sub(panel_height);
+        self.fill_rect_alpha(
+            panel_x,
+            panel_y,
+            panel_width,
+            panel_height,
+            rgb(0x08, 0x0a, 0x0f),
+            KEYBOARD_OVERLAY_PANEL_ALPHA,
+        );
+
+        let mut text = OverlayTextRenderer::new(text_settings.font_family.clone());
+        let mut y = panel_y.saturating_add(KEYBOARD_OVERLAY_INSET_Y);
+        for row in rows {
+            let row_width = keyboard_overlay_row_width(&row);
+            let mut x = panel_x.saturating_add(panel_width.saturating_sub(row_width) / 2);
+            for chip in row {
+                self.fill_rect_alpha(
+                    x,
+                    y,
+                    chip.width,
+                    row_height,
+                    rgb(0xf3, 0xf4, 0xf6),
+                    KEYBOARD_OVERLAY_CHIP_ALPHA,
+                );
+                text.draw(
+                    self,
+                    &chip.label,
+                    x.saturating_add(KEYBOARD_OVERLAY_CHIP_PAD_X),
+                    y.saturating_add(KEYBOARD_OVERLAY_CHIP_PAD_Y),
+                    chip.width
+                        .saturating_sub(KEYBOARD_OVERLAY_CHIP_PAD_X.saturating_mul(2)),
+                );
+                x = x
+                    .saturating_add(chip.width)
+                    .saturating_add(KEYBOARD_OVERLAY_CHIP_GAP);
+            }
+            y = y.saturating_add(row_height);
+        }
+    }
+
     /// Draw macOS-style window buttons.
     ///
     /// The current style language treats any non-empty mode as enabled. Modes ending in `Right`
@@ -873,6 +1011,69 @@ impl SolidFrame {
     }
 }
 
+/// One wrapped key chip ready for drawing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct KeyboardOverlayChip {
+    /// Display label.
+    label: String,
+    /// Approximate chip width in pixels.
+    width: u32,
+}
+
+/// Text renderer used for keyboard overlay labels.
+struct OverlayTextRenderer {
+    /// Preferred font family inherited from terminal text settings.
+    font_family: Option<String>,
+    /// Font database and shaping context.
+    font_system: FontSystem,
+    /// Glyph raster cache.
+    swash_cache: SwashCache,
+}
+
+impl OverlayTextRenderer {
+    /// Create a renderer for overlay text.
+    fn new(font_family: Option<String>) -> Self {
+        Self {
+            font_family,
+            font_system: FontSystem::new(),
+            swash_cache: SwashCache::new(),
+        }
+    }
+
+    /// Draw one overlay label, clipped to the provided width.
+    fn draw(&mut self, target: &mut SolidFrame, text: &str, x: u32, y: u32, width: u32) {
+        if width == 0 {
+            return;
+        }
+
+        let metrics = Metrics::new(KEYBOARD_OVERLAY_FONT_SIZE, KEYBOARD_OVERLAY_LINE_HEIGHT);
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+        let mut buffer = buffer.borrow_with(&mut self.font_system);
+        let family = self
+            .font_family
+            .as_deref()
+            .map(Family::Name)
+            .unwrap_or(Family::Monospace);
+        let attrs = Attrs::new().family(family);
+
+        buffer.set_size(Some(width as f32), Some(KEYBOARD_OVERLAY_LINE_HEIGHT));
+        buffer.set_text(text, &attrs, Shaping::Advanced, None);
+        buffer.draw(
+            &mut self.swash_cache,
+            Color::rgb(0x10, 0x18, 0x27),
+            |glyph_x, glyph_y, width, height, glyph_color| {
+                target.blend_rect(
+                    x as i32 + glyph_x,
+                    y as i32 + glyph_y,
+                    width,
+                    height,
+                    glyph_color,
+                );
+            },
+        );
+    }
+}
+
 /// Parse a `#RRGGBB` color.
 ///
 /// Decoration colors are parsed leniently. Invalid values return `None` so callers can fall back
@@ -903,6 +1104,200 @@ fn fit_cells(pixels: u32, cell_pixels: u32) -> u16 {
     u16::try_from(cells).unwrap_or(u16::MAX)
 }
 
+/// Parse the presentation mode accepted by `Set KeyboardOverlay`.
+fn parse_keyboard_overlay_mode(mode: &str) -> Result<KeyboardOverlayMode> {
+    match mode.to_ascii_lowercase().as_str() {
+        "off" => Ok(KeyboardOverlayMode::Off),
+        "keys" => Ok(KeyboardOverlayMode::Keys),
+        "input" => Ok(KeyboardOverlayMode::Input),
+        "all" => Ok(KeyboardOverlayMode::All),
+        _ => Err(
+            miette!("Set KeyboardOverlay expects Off, Keys, Input, or All, got `{mode}`").into(),
+        ),
+    }
+}
+
+/// Return the overlay label for one input-producing command.
+fn keyboard_overlay_label(command: &Command, mode: KeyboardOverlayMode) -> Option<String> {
+    match command {
+        Command::Type { text, .. } if mode == KeyboardOverlayMode::All && !text.is_empty() => {
+            Some(describe_overlay_type(text))
+        }
+        Command::Type { text, .. }
+            if mode == KeyboardOverlayMode::Input && is_short_input_text(text) =>
+        {
+            Some(format!("Type \"{}\"", describe_overlay_text(text)))
+        }
+        Command::Key { key, count, .. } if mode != KeyboardOverlayMode::Off => {
+            let key = describe_overlay_key(key);
+            if *count == 1 {
+                Some(key)
+            } else {
+                Some(format!("{key} x{count}"))
+            }
+        }
+        Command::Paste if matches!(mode, KeyboardOverlayMode::Input | KeyboardOverlayMode::All) => {
+            Some("Paste".to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Return the bounded set of recent labels shown in the HUD.
+fn recent_keyboard_overlay_labels(labels: &[String]) -> Vec<String> {
+    let start = labels.len().saturating_sub(KEYBOARD_OVERLAY_MAX_CHIPS);
+    labels[start..].to_vec()
+}
+
+/// Wrap overlay labels into bounded rows of key chips.
+fn keyboard_overlay_rows(labels: &[String], width: u32) -> Vec<Vec<KeyboardOverlayChip>> {
+    let usable_width = width
+        .saturating_sub(KEYBOARD_OVERLAY_INSET_X.saturating_mul(2))
+        .max(1);
+    let mut rows: Vec<Vec<KeyboardOverlayChip>> = Vec::new();
+    let mut current_row = Vec::new();
+    let mut current_width = 0u32;
+
+    for label in labels {
+        let chip = KeyboardOverlayChip {
+            label: label.clone(),
+            width: keyboard_overlay_chip_width(label, usable_width),
+        };
+        let gap = if current_row.is_empty() {
+            0
+        } else {
+            KEYBOARD_OVERLAY_CHIP_GAP
+        };
+        if !current_row.is_empty()
+            && current_width.saturating_add(gap).saturating_add(chip.width) > usable_width
+        {
+            rows.push(current_row);
+            current_row = Vec::new();
+            current_width = 0;
+        }
+        current_width = current_width
+            .saturating_add(if current_row.is_empty() {
+                0
+            } else {
+                KEYBOARD_OVERLAY_CHIP_GAP
+            })
+            .saturating_add(chip.width);
+        current_row.push(chip);
+    }
+
+    if !current_row.is_empty() {
+        rows.push(current_row);
+    }
+    if rows.len() > KEYBOARD_OVERLAY_MAX_ROWS {
+        let keep_from = rows.len() - KEYBOARD_OVERLAY_MAX_ROWS;
+        rows.drain(0..keep_from);
+        if let Some(first_row) = rows.first_mut() {
+            first_row.insert(
+                0,
+                KeyboardOverlayChip {
+                    label: "...".to_string(),
+                    width: keyboard_overlay_chip_width("...", usable_width),
+                },
+            );
+        }
+    }
+    rows
+}
+
+/// Approximate the width of one overlay row.
+fn keyboard_overlay_row_width(row: &[KeyboardOverlayChip]) -> u32 {
+    let chips_width = row
+        .iter()
+        .map(|chip| chip.width)
+        .fold(0u32, u32::saturating_add);
+    let gaps = row.len().saturating_sub(1).try_into().unwrap_or(u32::MAX);
+    chips_width.saturating_add(KEYBOARD_OVERLAY_CHIP_GAP.saturating_mul(gaps))
+}
+
+/// Estimate one key chip width while keeping very long labels inside the overlay.
+fn keyboard_overlay_chip_width(label: &str, usable_width: u32) -> u32 {
+    let text_width = label.chars().count() as u32 * KEYBOARD_OVERLAY_CHAR_WIDTH;
+    text_width
+        .saturating_add(KEYBOARD_OVERLAY_CHIP_PAD_X.saturating_mul(2))
+        .min(usable_width)
+        .max(KEYBOARD_OVERLAY_CHIP_PAD_X.saturating_mul(2))
+}
+
+/// Describe typed text compactly for the overlay.
+fn describe_overlay_text(text: &str) -> String {
+    let mut output = String::new();
+    let mut chars = text.chars();
+    for ch in chars.by_ref().take(KEYBOARD_OVERLAY_TYPE_MAX_CHARS) {
+        match ch {
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            ch => output.push(ch),
+        }
+    }
+    if chars.next().is_some() {
+        output.push_str("...");
+    }
+    output
+}
+
+/// Describe one `Type` command for the overlay.
+fn describe_overlay_type(text: &str) -> String {
+    if is_short_input_text(text) {
+        return format!("Type \"{}\"", describe_overlay_text(text));
+    }
+    format!("Type {} chars", text.chars().count())
+}
+
+/// Return whether typed text is short enough to show as user intent in `Input` mode.
+fn is_short_input_text(text: &str) -> bool {
+    !text.is_empty()
+        && text.chars().count() <= KEYBOARD_OVERLAY_TYPE_MAX_CHARS
+        && !text.chars().any(|ch| matches!(ch, '\n' | '\r' | ';'))
+}
+
+/// Describe a key press compactly for the overlay.
+fn describe_overlay_key(key: &Key) -> String {
+    let Key::Press { key, modifiers } = key;
+    let mut parts = Vec::new();
+    if modifiers.ctrl {
+        parts.push("Ctrl".to_string());
+    }
+    if modifiers.alt {
+        parts.push("Alt".to_string());
+    }
+    if modifiers.shift {
+        parts.push("Shift".to_string());
+    }
+    parts.push(describe_overlay_key_code(*key));
+    parts.join("+")
+}
+
+/// Describe the logical key code used by a key press.
+fn describe_overlay_key_code(key: KeyCode) -> String {
+    match key {
+        KeyCode::Backspace => "Backspace".to_string(),
+        KeyCode::Delete => "Delete".to_string(),
+        KeyCode::Down => "Down".to_string(),
+        KeyCode::End => "End".to_string(),
+        KeyCode::Enter => "Enter".to_string(),
+        KeyCode::Escape => "Escape".to_string(),
+        KeyCode::Function(number) => format!("F{number}"),
+        KeyCode::Home => "Home".to_string(),
+        KeyCode::Insert => "Insert".to_string(),
+        KeyCode::Left => "Left".to_string(),
+        KeyCode::PageDown => "PageDown".to_string(),
+        KeyCode::PageUp => "PageUp".to_string(),
+        KeyCode::Right => "Right".to_string(),
+        KeyCode::Space => "Space".to_string(),
+        KeyCode::Tab => "Tab".to_string(),
+        KeyCode::Up => "Up".to_string(),
+        KeyCode::Char(ch) => ch.to_string(),
+    }
+}
+
 /// Return whether a key is a recognized `Set` setting.
 ///
 /// This is separate from `apply_set`'s main match so diagnostics can distinguish unknown setting
@@ -928,6 +1323,7 @@ fn known_setting(key: &str) -> bool {
             | "WindowBarSize"
             | "BorderRadius"
             | "CursorBlink"
+            | "KeyboardOverlay"
             | "WaitTimeout"
             | "WaitPattern"
             | "Theme"
@@ -943,6 +1339,7 @@ fn setting_expected_type(key: &str) -> &'static str {
         | "BorderRadius" => "number",
         "TypingSpeed" => "duration",
         "CursorBlink" => "bool",
+        "KeyboardOverlay" => "Off, Keys, Input, or All",
         "WaitTimeout" => "duration or number",
         _ => "known value",
     }

--- a/crates/betamax/src/commands/new.tape
+++ b/crates/betamax/src/commands/new.tape
@@ -34,6 +34,8 @@
 #   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 30.
 #   Set TypingSpeed <time>          Set the typing speed of the terminal. Default is 50ms.
 #   Set CursorBlink <bool>          Toggle cursor blinking in captured frames
+#   Set KeyboardOverlay <mode>      Draw recent input labels over generated media
+#                                   Modes: Off, Keys, Input, All
 #   Set WaitTimeout <time>          Set the default timeout for Wait commands
 #   Set WaitPattern <regex>         Set the default regex for bare Wait commands
 #

--- a/docs/tape-reference.md
+++ b/docs/tape-reference.md
@@ -43,6 +43,7 @@ Common settings:
 | `PlaybackSpeed` | number                                     | `1.0`            | Changes output playback, not PTY timing.    |
 | `LoopOffset`    | number                                     | `0.0`            | `0..=1` is a fraction; otherwise seconds.   |
 | `CursorBlink`   | bool                                       | `true`           | Simulates a half-second blink cadence.      |
+| KeyboardOverlay | `Off`, `Keys`, `Input`, or `All`           | `Off`            | Draws recent input over generated media.    |
 | `WaitTimeout`   | duration or number                         | `15s`            | Number values are seconds.                  |
 | `WaitPattern`   | regex string                               | `>$`             | Used by `Wait` without explicit pattern.    |
 | `Margin`        | number                                     | `0`              | Outer decoration margin in pixels.          |
@@ -63,6 +64,18 @@ Treat larger `FontSize`, larger `Margin`, and decorative frame settings as prese
 the tape is proving modal placement, centered content, wrapping, or split-pane layout, prefer the
 default `FontSize`, default `Margin`, and a wider `Width` or `Height` so the proof matches the
 application layout rather than the demo framing.
+
+`Set KeyboardOverlay Input` draws a compact time-aware input HUD over generated PNG, GIF, video,
+screenshot, and frame-sequence media. Labels appear when input is queued and linger briefly after
+the input is typed, so review GIFs show the action near the terminal change it caused. The overlay
+is presentation-only: it does not change PTY input bytes, terminal dimensions, waits, or state JSON.
+
+Keyboard overlay modes are:
+
+- `Off`: no overlay.
+- `Keys`: explicit key commands only, such as `Ctrl+P`, `Down`, `Enter`, and `Escape`.
+- `Input`: key commands plus short typed input that reads like user intent.
+- `All`: every visible input event, including long `Type` commands summarized by character count.
 
 For built-in shell names such as `bash`, `zsh`, and `fish`, Betamax starts a clean recording shell
 with startup files and history disabled where possible. Those shells use the VHS-style colored `>`

--- a/examples/keyboard-overlay.tape
+++ b/examples/keyboard-overlay.tape
@@ -1,0 +1,28 @@
+Output examples/output/keyboard-overlay.gif
+Output examples/output/keyboard-overlay.png
+
+Require printf
+
+Set Shell "bash"
+Set Theme "GitHub Dark"
+Set FontSize 24
+Set Width 1040
+Set Height 560
+Set Margin 12
+Set WindowBar Colorful
+Set BorderRadius 8
+Set TypingSpeed 35ms
+Set CursorBlink false
+Set KeyboardOverlay Input
+
+Type "echo foo"
+Enter
+Wait+Screen "foo"
+
+Sleep 1800ms
+
+Type "echo bar"
+Enter
+Wait+Screen "bar"
+
+Sleep 900ms

--- a/site/public/assets/betamax-keyboard-overlay.gif
+++ b/site/public/assets/betamax-keyboard-overlay.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae5de5ec6d135bbbcf7c7f69b485a1b47106693866186d431716fa1c484b5bf8
+size 538601

--- a/site/public/assets/betamax-keyboard-overlay.png
+++ b/site/public/assets/betamax-keyboard-overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b3581ba5e065d0c610478e5d4967ba3def88aa4176bf3e6fd7cd88a45b707c3
+size 14306

--- a/site/src/content/docs/examples.mdx
+++ b/site/src/content/docs/examples.mdx
@@ -25,6 +25,7 @@ also live under `site/public/assets` with Git LFS. See
 | [`hide-show.tape`][hide-show-src]         | hidden setup and hidden trailing cleanup        | [Hidden work](../authoring/tape-files/#hidden-work)                    |
 | [`waits.tape`][waits-src]                 | line, screen, regex, and default prompt waits   | [Wait commands](../reference/tape-reference/#waitduration-regextext)   |
 | [`keys.tape`][keys-src]                   | key commands, repeats, editing, and interrupt   | [Key commands](../reference/tape-reference/#key-commands)              |
+| [keyboard-overlay][keyboard-overlay-src]  | input labels over review media                  | [Keyboard overlay](../reference/tape-reference/#settings)              |
 | [`clipboard-env.tape`][clipboard-env-src] | `Env`, `Copy`, and `Paste`                      | [Tape reference](../reference/tape-reference/#copy-text-and-paste)     |
 | [`captions.tape`][captions-src]           | visual captions for review media                | [Caption command](../reference/tape-reference/#caption-text)           |
 | [`outputs.tape`][outputs-src]             | GIF, PNG, JSON, screenshot, state, frame dir    | [Outputs](../authoring/outputs/)                                       |
@@ -67,6 +68,14 @@ updates terminal state, but the animation starts only when `Show` reveals the pr
 `captions.tape` annotates rendered media without changing the terminal session. Caption changes are
 presentation metadata: waits and state outputs keep matching the terminal itself.
 
+### Keyboard Overlay
+
+![Keyboard overlay Betamax GIF](/betamax/assets/betamax-keyboard-overlay.gif)
+
+`keyboard-overlay.tape` shows typed commands and key presses as compact labels over generated media.
+Labels appear when input is queued and linger briefly after typing, which keeps review GIFs readable
+without turning the overlay into a permanent command log.
+
 ### Themes
 
 ![Ghostty theme Betamax GIF](https://github.com/joshka/betamax/releases/download/readme-assets/themes.gif)
@@ -98,6 +107,7 @@ Use `examples/waits.tape` when debugging timing. It shows the three wait targets
 [captions-src]: https://github.com/joshka/betamax/blob/main/examples/captions.tape
 [clipboard-env-src]: https://github.com/joshka/betamax/blob/main/examples/clipboard-env.tape
 [hide-show-src]: https://github.com/joshka/betamax/blob/main/examples/hide-show.tape
+[keyboard-overlay-src]: https://github.com/joshka/betamax/blob/main/examples/keyboard-overlay.tape
 [keys-src]: https://github.com/joshka/betamax/blob/main/examples/keys.tape
 [layout-src]: https://github.com/joshka/betamax/blob/main/examples/layout.tape
 [outputs-src]: https://github.com/joshka/betamax/blob/main/examples/outputs.tape

--- a/site/src/content/docs/reference/tape-reference.mdx
+++ b/site/src/content/docs/reference/tape-reference.mdx
@@ -62,6 +62,7 @@ an error rather than a quiet fallback.
 | `PlaybackSpeed` | number                | `1.0`            | Output playback multiplier; does not speed up command execution       |
 | `LoopOffset`    | number or percentage  | `0.0`            | Rotates animated output frames to move the loop boundary              |
 | `CursorBlink`   | bool                  | `true`           | Simulates cursor blink in captured frames                             |
+| KeyboardOverlay | enum                  | `Off`            | Draws recent input over generated media                               |
 | `WaitTimeout`   | duration or number    | `15s`            | Default timeout for wait commands; bare numbers are seconds           |
 | `WaitPattern`   | regex string          | `>$`             | Regex used by bare `Wait`                                             |
 | `Margin`        | number                | `0`              | Outer decoration margin in pixels                                     |
@@ -79,6 +80,18 @@ Treat larger `FontSize`, larger `Margin`, and decorative frame settings as prese
 the tape is proving modal placement, centered content, wrapping, or split-pane layout, prefer the
 default `FontSize`, default `Margin`, and a wider `Width` or `Height` so the proof matches the
 application layout rather than the demo framing.
+
+`Set KeyboardOverlay Input` draws a compact time-aware input HUD over generated PNG, GIF, video,
+screenshot, and frame-sequence media. Labels appear when input is queued and linger briefly after
+the input is typed, so review GIFs show the action near the terminal change it caused. The overlay
+is presentation-only: it does not change PTY input bytes, terminal dimensions, waits, or state JSON.
+
+Keyboard overlay modes are:
+
+- `Off`: no overlay.
+- `Keys`: explicit key commands only, such as `Ctrl+P`, `Down`, `Enter`, and `Escape`.
+- `Input`: key commands plus short typed input that reads like user intent.
+- `All`: every visible input event, including long `Type` commands summarized by character count.
 
 ## Command Reference
 


### PR DESCRIPTION
## Summary

- add `Set KeyboardOverlay Off|Keys|Input|All` for presentation-only input labels in generated media
- render time-aware keyboard overlay labels that linger briefly after input without changing PTY behavior, waits, sizing, or state JSON
- add a docs/example tape plus LFS-backed GIF/PNG preview assets

## Preview

![Keyboard overlay preview](https://media.githubusercontent.com/media/joshka/betamax/2ac950c2c82de1b49ee09ec2a67f9fc0d55791ad/site/public/assets/betamax-keyboard-overlay.gif)

## Validation

- `mise run fmt-check`
- `mise run test`
- `mise run validate`
- `mise run lint-md`
- `mise run docs-site-check`
- `mise run docs-site-build`

## LFS checks

- docs GIF/PNG are tracked with Git LFS
- committed media blobs are pointer-sized text blobs
- LFS objects uploaded before branch push
- commit-hosted preview URL returns `GIF89a`
- PR #86 caption GIF was checked separately and is also LFS-backed; its hosted media URL returns `GIF89a`
