### PR TITLE
Add caption behavior tests

### DIFF
--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -1100,6 +1100,13 @@ mod tests {
         assert!(frames_equal(&capture.frames[0].0.frame, &frame));
     }
 
+    #[test]
+    fn empty_caption_text_clears_overlay_state() {
+        assert_eq!(active_caption(""), None);
+        assert_eq!(active_caption("   "), None);
+        assert_eq!(active_caption("  Step 1  ").as_deref(), Some("  Step 1  "));
+    }
+
     fn test_frame(pixel: [u8; 4]) -> Frame {
         sized_test_frame(1, 1, pixel)
     }

--- a/crates/betamax-core/src/tape/parser.rs
+++ b/crates/betamax-core/src/tape/parser.rs
@@ -584,6 +584,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_empty_caption_for_clear() {
+        let tape = Tape::parse(r#"Caption "" Caption "Next""#).unwrap();
+        assert_eq!(
+            tape.commands,
+            vec![
+                Command::Caption(String::new()),
+                Command::Caption("Next".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn parses_documentation_style_tape() {
         let tape = Tape::parse(
             r##"

--- a/crates/betamax-core/tests/public_api.rs
+++ b/crates/betamax-core/tests/public_api.rs
@@ -104,6 +104,67 @@ fn runner_accepts_custom_capture_backend() {
     let _ = fs::remove_file(output);
 }
 
+#[test]
+fn captions_affect_screenshots_not_state_json() {
+    let final_state = temp_output("betamax-public-api-caption-final.json");
+    let checkpoint_state = temp_output("betamax-public-api-caption-checkpoint.json");
+    let plain_screenshot = temp_output("betamax-public-api-caption-plain.png");
+    let captioned_screenshot = temp_output("betamax-public-api-caption-captioned.png");
+    let caption = "Review-only caption";
+    let tape = Tape::parse(&format!(
+        r#"
+        Output {final_state}
+        Set Shell "bash"
+        Set Width 180
+        Set Height 120
+        Set Padding 0
+        Screenshot {plain_screenshot}
+        Caption "{caption}"
+        Screenshot {captioned_screenshot}
+        Type "printf 'terminal only\n'"
+        Enter
+        Wait+Screen "terminal only"
+        State {checkpoint_state}
+        "#,
+        final_state = final_state.display(),
+        plain_screenshot = plain_screenshot.display(),
+        captioned_screenshot = captioned_screenshot.display(),
+        checkpoint_state = checkpoint_state.display(),
+    ))
+    .unwrap();
+
+    let artifacts = Runner::with_capture(
+        RunOptions {
+            publish: false,
+            quiet: true,
+        },
+        FakeCapture,
+    )
+    .run_artifacts(&tape)
+    .unwrap();
+
+    let final_json = fs::read_to_string(&final_state).unwrap();
+    let checkpoint_json = fs::read_to_string(&checkpoint_state).unwrap();
+    let plain_png = fs::read(&plain_screenshot).unwrap();
+    let captioned_png = fs::read(&captioned_screenshot).unwrap();
+
+    assert_eq!(artifacts.output_paths, vec![final_state.clone()]);
+    assert!(final_json.contains("terminal only"));
+    assert!(!final_json.contains(caption));
+    assert!(checkpoint_json.contains("terminal only"));
+    assert!(!checkpoint_json.contains(caption));
+    assert_ne!(plain_png, captioned_png);
+
+    for path in [
+        final_state,
+        checkpoint_state,
+        plain_screenshot,
+        captioned_screenshot,
+    ] {
+        let _ = fs::remove_file(path);
+    }
+}
+
 fn temp_output(name: &str) -> PathBuf {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Summary
- add parser coverage for `Caption ""` clear syntax
- add runner coverage for whitespace-only captions clearing the active overlay
- add a public runner integration test proving captions change screenshots but stay out of state JSON

Follow-up to #86 after the caption feature merged.

## Validation
- `cargo test -p betamax-core caption -- --nocapture`
- `mise run test`
- `mise run clippy`
