### PR TITLE
Place presentation overlays outside terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,22 +114,23 @@ and settings behavior.
 
 The checked-in examples are small smoke-test tapes that demonstrate core behavior:
 
-| Tape                             | Demonstrates                                   | Main Output         |
-| -------------------------------- | ---------------------------------------------- | ------------------- |
-| `examples/quick-start.tape`      | installing, help, `new`, and nested `run`      | `quick-start.gif`   |
-| `examples/basic.tape`            | typing, wait, theme, window bar, border radius | `basic.gif`         |
-| `examples/hide-show.tape`        | hidden setup and hidden trailing cleanup       | `hide-show.gif`     |
-| `examples/waits.tape`            | line, screen, regex, and default prompt waits  | `waits.gif`         |
-| `examples/keys.tape`             | key commands, repeats, editing, and interrupt  | `keys.gif`          |
-| `examples/clipboard-env.tape`    | `Env`, `Copy`, and `Paste`                     | `clipboard-env.gif` |
-| `examples/captions.tape`         | visual captions for review media               | `captions.*`        |
-| `examples/outputs.tape`          | GIF, PNG, JSON, screenshot, state, frame dir   | `outputs.*`         |
-| `examples/scrollback.tape`       | scrollback-inclusive state JSON                | `scrollback.*`      |
-| `examples/text-styles.tape`      | ANSI styles, truecolor, and styled state spans | `text-styles.*`     |
-| `examples/layout.tape`           | padding, margin, fill, window bar, radius      | `layout.gif`        |
-| `examples/themes.tape`           | copied Ghostty themes and palette mapping      | `themes.gif`        |
-| `examples/screenshot.tape`       | screenshots and terminal state JSON            | `screenshot.png`    |
-| `examples/video.tape`            | GIF, MP4, and WebM from one capture            | `video.*`           |
+| Tape                                      | Demonstrates                                   | Main Output               |
+| ----------------------------------------- | ---------------------------------------------- | ------------------------- |
+| `examples/quick-start.tape`               | installing, help, `new`, and nested `run`      | `quick-start.gif`         |
+| `examples/basic.tape`                     | typing, wait, theme, window bar, border radius | `basic.gif`               |
+| `examples/hide-show.tape`                 | hidden setup and hidden trailing cleanup       | `hide-show.gif`           |
+| `examples/waits.tape`                     | line, screen, regex, and default prompt waits  | `waits.gif`               |
+| `examples/keys.tape`                      | key commands, repeats, editing, and interrupt  | `keys.gif`                |
+| `examples/clipboard-env.tape`             | `Env`, `Copy`, and `Paste`                     | `clipboard-env.gif`       |
+| `examples/captions.tape`                  | visual captions for review media               | `captions.*`              |
+| `examples/presentation-overlays.tape`     | captions plus keyboard overlay layout          | `presentation-overlays.*` |
+| `examples/outputs.tape`                   | GIF, PNG, JSON, screenshot, state, frame dir   | `outputs.*`               |
+| `examples/scrollback.tape`                | scrollback-inclusive state JSON                | `scrollback.*`            |
+| `examples/text-styles.tape`               | ANSI styles, truecolor, and styled state spans | `text-styles.*`           |
+| `examples/layout.tape`                    | padding, margin, fill, window bar, radius      | `layout.gif`              |
+| `examples/themes.tape`                    | copied Ghostty themes and palette mapping      | `themes.gif`              |
+| `examples/screenshot.tape`                | screenshots and terminal state JSON            | `screenshot.png`          |
+| `examples/video.tape`                     | GIF, MP4, and WebM from one capture            | `video.*`                 |
 
 ### Quick Start
 
@@ -146,6 +147,15 @@ The checked-in examples are small smoke-test tapes that demonstrate core behavio
 ### Themes
 
 ![Ghostty theme Betamax GIF][themes-gif]
+
+### Presentation Overlays
+
+Captions and keyboard overlay chips are visual annotations for review media. When a tape uses
+`Caption` or enables `KeyboardOverlay`, Betamax reserves a bottom presentation row before deriving
+the terminal grid so labels do not cover terminal content. Captions align to the left edge of the
+terminal frame, keyboard chips align to the right edge, and long captions truncate with `...`
+instead of wrapping into the chips. Caption glyphs are clipped to their reserved width as a final
+guard for font fallback and unusually wide characters.
 
 ### Video
 

--- a/crates/betamax-core/src/runner/capture.rs
+++ b/crates/betamax-core/src/runner/capture.rs
@@ -49,7 +49,7 @@ impl Default for CaptureState {
 /// Raw captured terminal frame plus presentation metadata for final media decoration.
 #[derive(Debug, Clone)]
 pub(super) struct CapturedFrame {
-    /// Raw terminal frame before final margin/window/caption/overlay decoration.
+    /// Raw terminal frame before final margin, window, and presentation-row decoration.
     pub(super) frame: Frame,
     /// Caption active when this frame was captured.
     pub(super) caption: Option<String>,

--- a/crates/betamax-core/src/runner/mod.rs
+++ b/crates/betamax-core/src/runner/mod.rs
@@ -1058,8 +1058,8 @@ mod tests {
     fn keyboard_overlay_changes_pixels_without_resizing_output() {
         let tape = Tape::parse(
             r#"
-            Set Width 80
-            Set Height 40
+            Set Width 180
+            Set Height 120
             Set Padding 0
             Set KeyboardOverlay Input
             Type "abc"
@@ -1080,8 +1080,8 @@ mod tests {
         let rgba = decorated.rgba().unwrap();
         let bottom_left = rgba_pixel(&rgba, decorated.width, 1, decorated.height - 1);
 
-        assert_eq!(decorated.width, 80);
-        assert_eq!(decorated.height, 40);
+        assert_eq!(decorated.width, 180);
+        assert_eq!(decorated.height, 120);
         assert_ne!(bottom_left, [255, 0, 0, 255]);
     }
 
@@ -1165,6 +1165,7 @@ mod tests {
             Set Width 180
             Set Height 120
             Set Padding 0
+            Caption "Review checkpoint"
             "#,
         )
         .unwrap();
@@ -1185,6 +1186,48 @@ mod tests {
         assert_eq!(captioned.width, plain.width);
         assert_eq!(captioned.height, plain.height);
         assert_ne!(captioned.pixels, plain.pixels);
+    }
+
+    #[test]
+    fn presentation_overlays_reserve_space_below_terminal_canvas() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 220
+            Set Height 180
+            Set Padding 0
+            Set KeyboardOverlay Input
+            Caption "Step 1"
+            Type "abc"
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+
+        assert_eq!(settings.terminal_canvas_width(), 220);
+        assert!(settings.terminal_canvas_height() < 180);
+
+        let frame = sized_test_frame(
+            settings.terminal_canvas_width(),
+            settings.terminal_canvas_height(),
+            [255, 0, 0, 255],
+        );
+        let labels = vec!["Type \"abc\"".to_string()];
+        let decorated = settings
+            .decorate_frame_with_overlays(&frame, Some("Step 1"), &labels)
+            .unwrap();
+        let rgba = decorated.rgba().unwrap();
+
+        let terminal_bottom_y = settings.terminal_canvas_height().saturating_sub(1);
+        let first_overlay_y = settings.terminal_canvas_height();
+        let terminal_pixel = rgba_pixel(&rgba, decorated.width, 1, terminal_bottom_y);
+        let overlay_pixel = rgba_pixel(&rgba, decorated.width, 1, first_overlay_y);
+
+        assert_eq!(terminal_pixel, [255, 0, 0, 255]);
+        assert_ne!(overlay_pixel, [255, 0, 0, 255]);
+        assert_ne!(
+            rgba_pixel(&rgba, decorated.width, 110, decorated.height - 1),
+            [255, 0, 0, 255]
+        );
     }
 
     #[test]

--- a/crates/betamax-core/src/runner/settings.rs
+++ b/crates/betamax-core/src/runner/settings.rs
@@ -14,7 +14,9 @@ use std::env;
 use std::ffi::OsString;
 use std::time::Duration;
 
-use cosmic_text::{Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight};
+use cosmic_text::{
+    Attrs, Buffer, Color, Family, FontSystem, Metrics, Shaping, SwashCache, Weight, Wrap,
+};
 use miette::miette;
 use regex::Regex;
 
@@ -66,19 +68,15 @@ const CAPTION_FONT_SCALE: f32 = 0.9;
 /// Minimum readable caption font size.
 const MIN_CAPTION_FONT_SIZE: f32 = 14.0;
 /// Caption line height relative to caption font size.
-const CAPTION_LINE_HEIGHT: f32 = 1.35;
-/// Horizontal caption padding relative to caption font size.
-const CAPTION_HORIZONTAL_PADDING: f32 = 0.75;
+const CAPTION_LINE_HEIGHT: f32 = 1.2;
 /// Vertical caption padding relative to caption font size.
-const CAPTION_VERTICAL_PADDING: f32 = 0.45;
-/// Caption background alpha. The output frame remains fully opaque after blending.
-const CAPTION_BACKGROUND_ALPHA: u8 = 0xdd;
+const CAPTION_VERTICAL_PADDING: f32 = 0.25;
 /// Denominator for 8-bit alpha blending.
 const ALPHA_DENOMINATOR: u16 = 255;
 /// Maximum number of recent overlay events drawn over the output frame.
 const KEYBOARD_OVERLAY_MAX_CHIPS: usize = 5;
 /// Maximum number of overlay rows drawn over the output frame.
-const KEYBOARD_OVERLAY_MAX_ROWS: usize = 2;
+const KEYBOARD_OVERLAY_MAX_ROWS: usize = 1;
 /// Font size used by the compact keyboard overlay.
 const KEYBOARD_OVERLAY_FONT_SIZE: f32 = 18.0;
 /// Line height used by the compact keyboard overlay.
@@ -97,10 +95,10 @@ const KEYBOARD_OVERLAY_CHIP_PAD_Y: u32 = 4;
 const KEYBOARD_OVERLAY_CHIP_GAP: u32 = 8;
 /// Maximum number of displayed characters from one `Type` command.
 const KEYBOARD_OVERLAY_TYPE_MAX_CHARS: usize = 26;
-/// Alpha used for the overlay HUD.
-const KEYBOARD_OVERLAY_PANEL_ALPHA: u8 = 210;
 /// Alpha used for individual key chips.
 const KEYBOARD_OVERLAY_CHIP_ALPHA: u8 = 235;
+/// Gap between caption text and right-aligned keyboard chips.
+const PRESENTATION_OVERLAY_GAP: u32 = 16;
 
 /// Shell command and all derived execution, rendering, timing, and styling settings.
 ///
@@ -136,6 +134,8 @@ pub(super) struct Settings {
     pub(super) theme: TerminalTheme,
     /// Outer frame decoration settings.
     pub(super) style: StyleSettings,
+    /// Whether the tape uses presentation captions.
+    pub(super) caption_overlay: bool,
     /// Optional input-sequence overlay for review media.
     pub(super) keyboard_overlay: KeyboardOverlaySettings,
     /// Whether captured frames should blink the cursor according to the output framerate.
@@ -243,6 +243,7 @@ impl Settings {
             typing_delay: DEFAULT_TYPING_DELAY,
             text: TextSettings::default(),
             style: StyleSettings::new(&theme),
+            caption_overlay: false,
             keyboard_overlay: KeyboardOverlaySettings::default(),
             theme,
             cursor_blink: true,
@@ -255,6 +256,9 @@ impl Settings {
             match command {
                 Command::Env { key, value } => settings.env.push((key.clone(), value.clone())),
                 Command::Set { key, value } => settings.apply_set(key, value)?,
+                Command::Caption(text) if !text.trim().is_empty() => {
+                    settings.caption_overlay = true;
+                }
                 _ => {}
             }
         }
@@ -351,6 +355,7 @@ impl Settings {
         self.height
             .saturating_sub(self.effective_margin().saturating_mul(2))
             .saturating_sub(self.window_bar_height())
+            .saturating_sub(self.presentation_overlay_height())
     }
 
     /// VHS only applies margin when a margin fill is configured.
@@ -369,6 +374,49 @@ impl Settings {
         } else {
             self.style.window_bar_size
         }
+    }
+
+    /// Height reserved below the terminal canvas for presentation-only overlays.
+    fn presentation_overlay_height(&self) -> u32 {
+        self.caption_overlay_height()
+            .max(self.keyboard_overlay_height())
+    }
+
+    /// Height reserved for captions when any non-empty caption appears in the tape.
+    fn caption_overlay_height(&self) -> u32 {
+        if !self.caption_overlay {
+            return 0;
+        }
+        let font_size = self.caption_font_size();
+        let line_height = (font_size * CAPTION_LINE_HEIGHT).ceil() as u32;
+        let vertical_padding = (font_size * CAPTION_VERTICAL_PADDING).ceil() as u32;
+        line_height.saturating_add(vertical_padding.saturating_mul(2))
+    }
+
+    /// Height reserved for the largest keyboard overlay panel the configured mode can draw.
+    fn keyboard_overlay_height(&self) -> u32 {
+        if self.keyboard_overlay.mode == KeyboardOverlayMode::Off {
+            return 0;
+        }
+        let row_height = KEYBOARD_OVERLAY_LINE_HEIGHT.ceil() as u32;
+        KEYBOARD_OVERLAY_INSET_Y
+            .saturating_mul(2)
+            .saturating_add(row_height.saturating_mul(KEYBOARD_OVERLAY_MAX_ROWS as u32))
+    }
+
+    /// Font size used by caption rendering and layout reservation.
+    fn caption_font_size(&self) -> f32 {
+        (self.text.font_size * CAPTION_FONT_SCALE).max(MIN_CAPTION_FONT_SIZE)
+    }
+
+    /// Left edge for presentation content, aligned with the terminal frame.
+    fn presentation_overlay_left_x(&self) -> u32 {
+        self.effective_margin().min(self.width)
+    }
+
+    /// Right edge for presentation content, aligned with the terminal frame.
+    fn presentation_overlay_right_x(&self) -> u32 {
+        self.width.saturating_sub(self.effective_margin())
     }
 
     /// Derive terminal rows and columns from pixel dimensions.
@@ -489,9 +537,9 @@ impl Settings {
 
     /// Decorate a frame using a caller-owned caption renderer cache.
     ///
-    /// Decoration happens in final output coordinates: margin, window bar, rounded mask, then
-    /// caption overlay. Keeping captions last makes them independent from terminal canvas sizing
-    /// and guarantees the same overlay path for final PNGs, screenshots, GIFs, and videos.
+    /// Decoration happens in final output coordinates: margin, window bar, rounded mask, then the
+    /// presentation row for captions and keyboard labels. Keeping presentation drawing here
+    /// guarantees the same overlay path for final PNGs, screenshots, GIFs, and videos.
     fn decorate_frame_with_overlay_renderer(
         &self,
         frame: &Frame,
@@ -524,77 +572,88 @@ impl Settings {
                 fill,
             );
         }
-        if let Some(caption) = caption.filter(|caption| !caption.trim().is_empty()) {
-            self.draw_caption(&mut output, caption, caption_renderer);
+        let active_caption = caption.filter(|caption| !caption.trim().is_empty());
+        let keyboard_avoid_width = if self.keyboard_overlay.visible(keyboard_overlay_labels) {
+            keyboard_overlay_panel_width(keyboard_overlay_labels, output.width)
+                .saturating_add(PRESENTATION_OVERLAY_GAP)
+        } else {
+            0
+        };
+        if let Some(caption) = active_caption {
+            self.draw_caption(&mut output, caption, caption_renderer, keyboard_avoid_width);
         }
         if self.keyboard_overlay.visible(keyboard_overlay_labels) {
-            output.draw_keyboard_overlay(keyboard_overlay_labels, &self.text);
+            output.draw_keyboard_overlay(
+                keyboard_overlay_labels,
+                &self.text,
+                self.keyboard_overlay_bottom_y(),
+                self.presentation_overlay_right_x(),
+            );
         }
         Ok(output.into_frame())
     }
 
     /// Draw a caption into the final decorated frame.
     ///
-    /// The background is alpha-blended into the opaque output frame before text is drawn. This
-    /// keeps output formats simple while still making captions readable over arbitrary terminal
-    /// content.
+    /// Captions are clipped to their available row width and truncated with `...` when active
+    /// keyboard labels need space on the right.
     fn draw_caption(
         &self,
         output: &mut SolidFrame,
         caption: &str,
         caption_renderer: &mut CaptionRenderer,
+        avoid_right_width: u32,
     ) {
-        let Some(layout) = self.caption_layout() else {
+        let Some(layout) = self.caption_layout(avoid_right_width) else {
             return;
         };
-        output.fill_rect_alpha(
-            layout.x,
-            layout.y,
-            layout.width,
-            layout.height,
-            self.theme.background,
-            CAPTION_BACKGROUND_ALPHA,
-        );
         caption_renderer.draw(output, caption, layout, &self.text, self.theme.foreground);
     }
 
     /// Compute caption geometry in final output-frame coordinates.
     ///
-    /// The overlay spans the decorated content width inside the outer margin and is anchored to the
-    /// bottom of the final output. It may cover terminal pixels by design; tapes that need more
-    /// room should increase height, margin, or padding instead of changing PTY behavior.
-    fn caption_layout(&self) -> Option<CaptionLayout> {
-        let margin = self.effective_margin();
-        let width = self.width.saturating_sub(margin.saturating_mul(2));
+    /// The caption sits in the shared bottom presentation row below the terminal canvas. Keyboard
+    /// labels are right-aligned in the same row; the caption width is reduced so the two surfaces
+    /// do not overlap.
+    fn caption_layout(&self, avoid_right_width: u32) -> Option<CaptionLayout> {
+        if !self.caption_overlay {
+            return None;
+        }
+        let left_x = self.presentation_overlay_left_x();
+        let right_x = self.presentation_overlay_right_x();
+        let width = right_x
+            .saturating_sub(left_x)
+            .saturating_sub(avoid_right_width);
         if width == 0 || self.height == 0 {
             return None;
         }
 
-        let font_size = (self.text.font_size * CAPTION_FONT_SCALE).max(MIN_CAPTION_FONT_SIZE);
+        let font_size = self.caption_font_size();
         let line_height = (font_size * CAPTION_LINE_HEIGHT).ceil();
-        let horizontal_padding = (font_size * CAPTION_HORIZONTAL_PADDING).ceil() as u32;
         let vertical_padding = (font_size * CAPTION_VERTICAL_PADDING).ceil() as u32;
-        let height = (line_height as u32)
-            .saturating_add(vertical_padding.saturating_mul(2))
-            .min(self.height);
-        let text_width = width.saturating_sub(horizontal_padding.saturating_mul(2));
-        if text_width == 0 {
-            return None;
-        }
+        let height = self.presentation_overlay_height().min(self.height);
+        let caption_height = self.caption_overlay_height().min(height);
 
-        let y = self.height.saturating_sub(margin).saturating_sub(height);
+        let y = self
+            .height
+            .saturating_sub(self.effective_margin())
+            .saturating_sub(height);
+        let text_y = y
+            .saturating_add(height.saturating_sub(caption_height) / 2)
+            .saturating_add(vertical_padding);
         Some(CaptionLayout {
-            x: margin,
-            y,
-            width,
-            height,
-            text_x: margin.saturating_add(horizontal_padding),
-            text_y: y.saturating_add(vertical_padding),
-            text_width,
-            text_height: height.saturating_sub(vertical_padding.saturating_mul(2)),
+            text_x: left_x,
+            text_y,
+            text_width: width,
+            text_height: caption_height.saturating_sub(vertical_padding.saturating_mul(2)),
             font_size,
             line_height,
         })
+    }
+
+    /// Bottom edge for keyboard overlay chips in final output-frame coordinates.
+    fn keyboard_overlay_bottom_y(&self) -> u32 {
+        self.height.saturating_sub(self.effective_margin())
     }
 
     /// Return the keyboard overlay label for a visible input command, if enabled.
@@ -605,16 +664,36 @@ impl Settings {
 
 #[derive(Debug, Clone, Copy)]
 struct CaptionLayout {
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32,
     text_x: u32,
     text_y: u32,
     text_width: u32,
     text_height: u32,
     font_size: f32,
     line_height: f32,
+}
+
+impl CaptionLayout {
+    /// Return the caption text bounds as a clipping rectangle.
+    fn text_rect(self) -> PixelRect {
+        PixelRect {
+            x: self.text_x,
+            y: self.text_y,
+            width: self.text_width,
+            height: self.text_height,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PixelRect {
+    /// Left edge in output pixels.
+    x: u32,
+    /// Top edge in output pixels.
+    y: u32,
+    /// Width in output pixels.
+    width: u32,
+    /// Height in output pixels.
+    height: u32,
 }
 
 /// Text renderer for caption overlays.
@@ -640,8 +719,8 @@ impl CaptionRenderer {
 
     /// Draw caption text into the given layout.
     ///
-    /// The bounded text buffer clips overflow instead of resizing the media frame. That matches
-    /// the tape contract: captions are annotations on fixed-size output, not layout inputs.
+    /// Caption text is pre-truncated and drawn without wrapping. That keeps the presentation row
+    /// stable and avoids hiding terminal content or colliding with keyboard labels.
     fn draw(
         &mut self,
         target: &mut SolidFrame,
@@ -650,34 +729,97 @@ impl CaptionRenderer {
         text_settings: &TextSettings,
         color: libghostty_vt::style::RgbColor,
     ) {
-        let metrics = Metrics::new(layout.font_size, layout.line_height);
-        let mut buffer = Buffer::new(&mut self.font_system, metrics);
-        let mut buffer = buffer.borrow_with(&mut self.font_system);
         let family = text_settings
             .font_family
             .as_deref()
             .map(Family::Name)
             .unwrap_or(Family::Monospace);
         let attrs = Attrs::new().family(family).weight(Weight::BOLD);
+        let metrics = Metrics::new(layout.font_size, layout.line_height);
+        let caption = self.truncate_caption(caption, layout, metrics, &attrs);
 
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+        let mut buffer = buffer.borrow_with(&mut self.font_system);
         buffer.set_size(
             Some(layout.text_width as f32),
             Some(layout.text_height as f32),
         );
-        buffer.set_text(caption, &attrs, Shaping::Advanced, None);
+        buffer.set_wrap(Wrap::None);
+        buffer.set_text(&caption, &attrs, Shaping::Advanced, None);
         buffer.draw(
             &mut self.swash_cache,
             Color::rgb(color.r, color.g, color.b),
             |glyph_x, glyph_y, width, height, glyph_color| {
-                target.blend_rect(
+                target.blend_rect_clipped(
                     layout.text_x as i32 + glyph_x,
                     layout.text_y as i32 + glyph_y,
                     width,
                     height,
                     glyph_color,
+                    layout.text_rect(),
                 );
             },
         );
+    }
+
+    /// Truncate caption text with the same shaping stack used for drawing.
+    fn truncate_caption(
+        &mut self,
+        caption: &str,
+        layout: CaptionLayout,
+        metrics: Metrics,
+        attrs: &Attrs<'_>,
+    ) -> String {
+        const ELLIPSIS: &str = "...";
+
+        if self.caption_text_width(caption, layout, metrics, attrs) <= layout.text_width as f32 {
+            return caption.to_string();
+        }
+        if self.caption_text_width(ELLIPSIS, layout, metrics, attrs) > layout.text_width as f32 {
+            return ELLIPSIS.to_string();
+        }
+
+        let char_ends = caption
+            .char_indices()
+            .map(|(index, ch)| index + ch.len_utf8())
+            .collect::<Vec<_>>();
+        let mut low = 0;
+        let mut high = char_ends.len();
+        while low < high {
+            let mid = (low + high).div_ceil(2);
+            let candidate = format!("{}{}", &caption[..char_ends[mid - 1]], ELLIPSIS);
+            if self.caption_text_width(&candidate, layout, metrics, attrs)
+                <= layout.text_width as f32
+            {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+
+        if low == 0 {
+            return ELLIPSIS.to_string();
+        }
+        format!("{}{}", &caption[..char_ends[low - 1]], ELLIPSIS)
+    }
+
+    /// Measure a single caption line after font fallback and shaping.
+    fn caption_text_width(
+        &mut self,
+        caption: &str,
+        layout: CaptionLayout,
+        metrics: Metrics,
+        attrs: &Attrs<'_>,
+    ) -> f32 {
+        let mut buffer = Buffer::new(&mut self.font_system, metrics);
+        let mut buffer = buffer.borrow_with(&mut self.font_system);
+        buffer.set_size(None, Some(layout.text_height as f32));
+        buffer.set_wrap(Wrap::None);
+        buffer.set_text(caption, attrs, Shaping::Advanced, None);
+        buffer
+            .layout_runs()
+            .map(|run| run.line_w)
+            .fold(0.0, f32::max)
     }
 }
 
@@ -759,8 +901,8 @@ impl SolidFrame {
 
     /// Fill a clipped rectangle with alpha blending.
     ///
-    /// Caption backgrounds are composited onto an opaque frame instead of introducing transparent
-    /// output pixels, because the media encoders currently treat rendered frames as opaque RGBA.
+    /// Alpha fills are composited onto an opaque frame instead of introducing transparent output
+    /// pixels, because the media encoders currently treat rendered frames as opaque RGBA.
     fn fill_rect_alpha(
         &mut self,
         x: u32,
@@ -799,8 +941,50 @@ impl SolidFrame {
         }
     }
 
+    /// Alpha-blend a glyph rectangle clipped to a caller-provided rectangle.
+    fn blend_rect_clipped(
+        &mut self,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        color: Color,
+        clip: PixelRect,
+    ) {
+        let [r, g, b, a] = color.as_rgba();
+        if a == 0 {
+            return;
+        }
+        let Some((x0, y0, x1, y1)) = self.clipped_rect(x, y, width, height) else {
+            return;
+        };
+        let Some((clip_x0, clip_y0, clip_x1, clip_y1)) =
+            self.clipped_rect(clip.x as i32, clip.y as i32, clip.width, clip.height)
+        else {
+            return;
+        };
+        let x0 = x0.max(clip_x0);
+        let y0 = y0.max(clip_y0);
+        let x1 = x1.min(clip_x1);
+        let y1 = y1.min(clip_y1);
+        if x0 >= x1 || y0 >= y1 {
+            return;
+        }
+        for yy in y0..y1 {
+            for xx in x0..x1 {
+                self.blend_pixel(xx, yy, r, g, b, a);
+            }
+        }
+    }
+
     /// Draw the configured input sequence as compact key chips over the bottom of the frame.
-    fn draw_keyboard_overlay(&mut self, labels: &[String], text_settings: &TextSettings) {
+    fn draw_keyboard_overlay(
+        &mut self,
+        labels: &[String],
+        text_settings: &TextSettings,
+        bottom_y: u32,
+        right_x: u32,
+    ) {
         let labels = recent_keyboard_overlay_labels(labels);
         let rows = keyboard_overlay_rows(&labels, self.width);
         if rows.is_empty() {
@@ -820,17 +1004,8 @@ impl SolidFrame {
             .saturating_mul(2)
             .saturating_add(row_height.saturating_mul(rows.len() as u32))
             .min(self.height);
-        let panel_x = self.width.saturating_sub(panel_width) / 2;
-        let panel_y = self.height.saturating_sub(panel_height);
-        self.fill_rect_alpha(
-            panel_x,
-            panel_y,
-            panel_width,
-            panel_height,
-            rgb(0x08, 0x0a, 0x0f),
-            KEYBOARD_OVERLAY_PANEL_ALPHA,
-        );
-
+        let panel_x = right_x.min(self.width).saturating_sub(panel_width);
+        let panel_y = bottom_y.min(self.height).saturating_sub(panel_height);
         let mut text = OverlayTextRenderer::new(text_settings.font_family.clone());
         let mut y = panel_y.saturating_add(KEYBOARD_OVERLAY_INSET_Y);
         for row in rows {
@@ -1204,6 +1379,17 @@ fn keyboard_overlay_rows(labels: &[String], width: u32) -> Vec<Vec<KeyboardOverl
     rows
 }
 
+/// Width of the right-aligned keyboard overlay area for the current labels.
+fn keyboard_overlay_panel_width(labels: &[String], width: u32) -> u32 {
+    keyboard_overlay_rows(&recent_keyboard_overlay_labels(labels), width)
+        .iter()
+        .map(|row| keyboard_overlay_row_width(row))
+        .max()
+        .unwrap_or(0)
+        .saturating_add(KEYBOARD_OVERLAY_INSET_X.saturating_mul(2))
+        .min(width)
+}
+
 /// Approximate the width of one overlay row.
 fn keyboard_overlay_row_width(row: &[KeyboardOverlayChip]) -> u32 {
     let chips_width = row
@@ -1352,5 +1538,120 @@ fn value_kind(value: &Value) -> &'static str {
         Value::Number(_) => "number",
         Value::Duration(_) => "duration",
         Value::Bool(_) => "bool",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pixel(frame: &SolidFrame, x: u32, y: u32) -> [u8; 4] {
+        let offset = frame.offset(x, y);
+        [
+            frame.pixels[offset],
+            frame.pixels[offset + 1],
+            frame.pixels[offset + 2],
+            frame.pixels[offset + 3],
+        ]
+    }
+
+    #[test]
+    fn caption_truncation_uses_shaped_width_and_three_dots() {
+        let mut renderer = CaptionRenderer::new();
+        let layout = CaptionLayout {
+            text_x: 0,
+            text_y: 0,
+            text_width: 150,
+            text_height: 28,
+            font_size: 20.0,
+            line_height: 24.0,
+        };
+        let metrics = Metrics::new(layout.font_size, layout.line_height);
+        let attrs = Attrs::new().family(Family::Monospace).weight(Weight::BOLD);
+        let caption = "The bottom terminal row remains visible beside the key chips";
+
+        let truncated = renderer.truncate_caption(caption, layout, metrics, &attrs);
+
+        assert!(truncated.ends_with("..."));
+        assert!(truncated.len() < caption.len());
+        assert!(
+            renderer.caption_text_width(&truncated, layout, metrics, &attrs)
+                <= layout.text_width as f32
+        );
+    }
+
+    #[test]
+    fn caption_truncation_uses_full_ellipsis_when_space_is_tiny() {
+        let mut renderer = CaptionRenderer::new();
+        let layout = CaptionLayout {
+            text_x: 0,
+            text_y: 0,
+            text_width: 1,
+            text_height: 28,
+            font_size: 20.0,
+            line_height: 24.0,
+        };
+        let metrics = Metrics::new(layout.font_size, layout.line_height);
+        let attrs = Attrs::new().family(Family::Monospace).weight(Weight::BOLD);
+
+        assert_eq!(
+            renderer.truncate_caption("overflow", layout, metrics, &attrs),
+            "..."
+        );
+    }
+
+    #[test]
+    fn caption_glyph_blending_is_clipped_to_the_caption_rect() {
+        let mut frame = SolidFrame::new(10, 10, rgb(0, 0, 0)).unwrap();
+
+        frame.blend_rect_clipped(
+            0,
+            0,
+            10,
+            10,
+            Color::rgb(255, 0, 0),
+            PixelRect {
+                x: 2,
+                y: 3,
+                width: 4,
+                height: 2,
+            },
+        );
+
+        assert_eq!(pixel(&frame, 1, 3), [0, 0, 0, 255]);
+        assert_ne!(pixel(&frame, 2, 3), [0, 0, 0, 255]);
+        assert_ne!(pixel(&frame, 5, 4), [0, 0, 0, 255]);
+        assert_eq!(pixel(&frame, 6, 4), [0, 0, 0, 255]);
+        assert_eq!(pixel(&frame, 2, 5), [0, 0, 0, 255]);
+    }
+
+    #[test]
+    fn caption_layout_shares_terminal_frame_edges_with_keyboard_overlay() {
+        let tape = Tape::parse(
+            r#"
+            Set Width 320
+            Set Height 200
+            Set Margin 16
+            Set KeyboardOverlay Input
+            Caption "Long caption"
+            Type "echo done"
+            "#,
+        )
+        .unwrap();
+        let settings = Settings::from_tape(&tape).unwrap();
+        let labels = vec!["Type \"echo done\"".to_string()];
+        let avoid_width = keyboard_overlay_panel_width(&labels, settings.width)
+            .saturating_add(PRESENTATION_OVERLAY_GAP);
+        let layout = settings.caption_layout(avoid_width).unwrap();
+
+        assert_eq!(layout.text_x, 16);
+        assert_eq!(
+            layout.text_width,
+            settings
+                .width
+                .saturating_sub(32)
+                .saturating_sub(avoid_width)
+        );
+        assert_eq!(settings.presentation_overlay_right_x(), 304);
     }
 }

--- a/crates/betamax/README.md
+++ b/crates/betamax/README.md
@@ -122,20 +122,21 @@ stable even when terminal programs do real work.
 
 The repository includes tapes that exercise the core behavior:
 
-| Tape                          | Demonstrates                                   |
-| ----------------------------- | ---------------------------------------------- |
-| `examples/quick-start.tape`   | installing, help, `new`, and nested `run`      |
-| `examples/basic.tape`         | typing, wait, theme, window bar, border radius |
-| `examples/hide-show.tape`     | hidden setup and hidden trailing cleanup       |
-| `examples/waits.tape`         | line, screen, regex, and default prompt waits  |
-| `examples/keys.tape`          | key commands, repeats, editing, and interrupt  |
-| `examples/clipboard-env.tape` | `Env`, `Copy`, and `Paste`                     |
-| `examples/outputs.tape`       | GIF, PNG, JSON, screenshot, state, frame dir   |
-| `examples/scrollback.tape`    | scrollback-inclusive state JSON                |
-| `examples/text-styles.tape`   | ANSI styles, truecolor, and styled state spans |
-| `examples/layout.tape`        | padding, margin, fill, window bar, radius      |
-| `examples/themes.tape`        | copied Ghostty themes and palette mapping      |
-| `examples/video.tape`         | GIF, MP4, and WebM from one capture            |
+| Tape                                      | Demonstrates                                   |
+| ----------------------------------------- | ---------------------------------------------- |
+| `examples/quick-start.tape`               | installing, help, `new`, and nested `run`      |
+| `examples/basic.tape`                     | typing, wait, theme, window bar, border radius |
+| `examples/hide-show.tape`                 | hidden setup and hidden trailing cleanup       |
+| `examples/waits.tape`                     | line, screen, regex, and default prompt waits  |
+| `examples/keys.tape`                      | key commands, repeats, editing, and interrupt  |
+| `examples/clipboard-env.tape`             | `Env`, `Copy`, and `Paste`                     |
+| `examples/outputs.tape`                   | GIF, PNG, JSON, screenshot, state, frame dir   |
+| `examples/scrollback.tape`                | scrollback-inclusive state JSON                |
+| `examples/text-styles.tape`               | ANSI styles, truecolor, and styled state spans |
+| `examples/layout.tape`                    | padding, margin, fill, window bar, radius      |
+| `examples/presentation-overlays.tape`     | captions plus keyboard overlay layout          |
+| `examples/themes.tape`                    | copied Ghostty themes and palette mapping      |
+| `examples/video.tape`                     | GIF, MP4, and WebM from one capture            |
 
 ### Quick Start
 
@@ -167,6 +168,12 @@ Tapes can control width, height, font size, padding, margin, border radius, wind
 color, typing speed, playback speed, and prompt text. The defaults are chosen to feel close to VHS:
 a readable terminal size, a visible frame, and a simple `>` prompt unless a tape asks for a real
 shell prompt.
+
+Captions and keyboard overlay chips are presentation-only annotations for visual outputs. When a
+tape uses them, Betamax reserves a bottom presentation row before deriving the terminal grid so
+labels do not cover terminal content. Captions align left, keyboard chips align right, and long
+captions truncate with `...` instead of wrapping into the chips. Caption glyphs are clipped to their
+reserved width as a final guard for font fallback and unusually wide characters.
 
 ## Terminal Testing
 

--- a/docs/tape-reference.md
+++ b/docs/tape-reference.md
@@ -43,7 +43,7 @@ Common settings:
 | `PlaybackSpeed` | number                                     | `1.0`            | Changes output playback, not PTY timing.    |
 | `LoopOffset`    | number                                     | `0.0`            | `0..=1` is a fraction; otherwise seconds.   |
 | `CursorBlink`   | bool                                       | `true`           | Simulates a half-second blink cadence.      |
-| KeyboardOverlay | `Off`, `Keys`, `Input`, or `All`           | `Off`            | Draws recent input over generated media.    |
+| KeyboardOverlay | `Off`, `Keys`, `Input`, or `All`           | `Off`            | Shows recent input chips in media.          |
 | `WaitTimeout`   | duration or number                         | `15s`            | Number values are seconds.                  |
 | `WaitPattern`   | regex string                               | `>$`             | Used by `Wait` without explicit pattern.    |
 | `Margin`        | number                                     | `0`              | Outer decoration margin in pixels.          |
@@ -55,20 +55,23 @@ Common settings:
 Unknown settings and type mismatches are errors. For example, `Set Wdith 900` and
 `Set Width "wide"` fail before the shell starts instead of silently falling back to defaults.
 
-The terminal grid is derived after all settings are applied. Margin and window-bar decoration are
-subtracted from width and height first, then padding, font size, letter spacing, and line height
-determine the PTY columns and rows. Extremely small dimensions are clamped to at least one row and
-one column.
+The terminal grid is derived after all settings are applied. Margin, window-bar decoration, and any
+presentation row needed for captions or keyboard overlay are subtracted from width and height first,
+then padding, font size, letter spacing, and line height determine the PTY columns and rows.
+Extremely small dimensions are clamped to at least one row and one column.
 
 Treat larger `FontSize`, larger `Margin`, and decorative frame settings as presentation zoom. When
 the tape is proving modal placement, centered content, wrapping, or split-pane layout, prefer the
 default `FontSize`, default `Margin`, and a wider `Width` or `Height` so the proof matches the
 application layout rather than the demo framing.
 
-`Set KeyboardOverlay Input` draws a compact time-aware input HUD over generated PNG, GIF, video,
+`Set KeyboardOverlay Input` draws compact time-aware input chips on generated PNG, GIF, video,
 screenshot, and frame-sequence media. Labels appear when input is queued and linger briefly after
 the input is typed, so review GIFs show the action near the terminal change it caused. The overlay
-is presentation-only: it does not change PTY input bytes, terminal dimensions, waits, or state JSON.
+is presentation-only: it does not change PTY input bytes, waits, state JSON, or final output
+dimensions. When enabled, Betamax reserves a bottom presentation row before deriving the terminal
+grid so chips do not cover terminal content. Keyboard chips are right-aligned to the terminal frame
+edge and share the row with captions when both are active.
 
 Keyboard overlay modes are:
 
@@ -206,16 +209,22 @@ Sets a caption rendered onto later visual media frames. The text is one token, s
 that contain spaces. Use `Caption ""` to clear the active caption.
 
 Captions are presentation metadata only. They do not write to the PTY, alter terminal state, affect
-wait matching, or change output dimensions. Active captions appear on GIF, PNG, MP4, WebM, frame
-directory, and `Screenshot` outputs. `State` JSON does not include captions.
+wait matching, or change final output dimensions. Active captions appear on GIF, PNG, MP4, WebM,
+frame directory, and `Screenshot` outputs. `State` JSON does not include captions. When a tape
+contains a caption, Betamax reserves a bottom presentation row before deriving the terminal grid so
+captions do not cover terminal content.
 
 `Caption` does not capture a frame or add time to animated output by itself. The new caption appears
 on the next visual frame Betamax renders, such as a frame captured during a later `Sleep`, `Wait`,
 typing, key press, `Show`, final-frame output, or `Screenshot`. Add `Sleep` after a caption-only
 change when an animation should dwell on the new caption without changing terminal content.
 
-Betamax renders captions as a bottom overlay. If the overlay covers important terminal content,
-increase the tape height, margin, or padding, or clear the caption before the affected frame.
+Betamax renders captions below the terminal canvas, left-aligned with the terminal frame edge.
+Captions are single-line presentation text: if a caption does not fit beside right-aligned keyboard
+chips, Betamax truncates it with `...` instead of wrapping. Caption glyphs are clipped to their
+reserved width as a final guard for font fallback and unusually wide characters. If the caption or
+keyboard overlay needs more room, increase the tape height or reduce presentation chrome such as
+margin and window bar size.
 
 ### `Screenshot <path>.png`
 

--- a/examples/presentation-overlays.tape
+++ b/examples/presentation-overlays.tape
@@ -1,0 +1,30 @@
+Output examples/output/presentation-overlays.gif
+Output examples/output/presentation-overlays.png
+
+Require printf
+
+Set Shell "bash"
+Set Theme "GitHub Dark"
+Set FontSize 24
+Set Width 1040
+Set Height 600
+Set Margin 16
+Set WindowBar Colorful
+Set BorderRadius 8
+Set TypingSpeed 35ms
+Set CursorBlink false
+Set KeyboardOverlay Input
+
+Caption "Caption and keyboard chips stay below the terminal"
+Type "printf 'hotbar: [F1 Help] [F2 Open] [F3 Save]\n'"
+Enter
+Wait+Screen "hotbar"
+
+Sleep 900ms
+
+Caption "The bottom terminal row remains visible"
+Type "echo done"
+Enter
+Wait+Screen "done"
+
+Sleep 900ms

--- a/site/src/content/docs/authoring/outputs.mdx
+++ b/site/src/content/docs/authoring/outputs.mdx
@@ -32,7 +32,8 @@ and styles without doing pixel comparisons.
 
 Use [`Caption`](../../reference/tape-reference/#caption-text) when generated visual media should
 explain a workflow step or review checkpoint without changing terminal behavior. Captions render on
-visual outputs only; they do not appear in state JSON.
+visual outputs only; they do not appear in state JSON. Captions share a bottom presentation row with
+keyboard overlay chips when both are active.
 
 Frame directories are useful when debugging capture timing or feeding rendered frames to custom
 tooling. The path must not have an extension; `Output target/frames` writes numbered PNG files under
@@ -108,6 +109,13 @@ Captions annotate rendered media without changing the terminal session. They are
 or screenshot needs to explain hidden setup, a review checkpoint, or a step in a TUI flow. Keep
 semantic checks in waits and state outputs; captions are presentation metadata.
 
+When a tape uses captions, Betamax reserves a bottom presentation row before deriving the terminal
+grid. Captions render below the terminal canvas instead of covering terminal rows. They are
+left-aligned with the terminal frame edge and remain single-line; if a caption needs to share space
+with right-aligned keyboard overlay chips, Betamax truncates it with `...` instead of wrapping.
+Caption glyphs are clipped to their reserved width as a final guard for font fallback and unusually
+wide characters.
+
 ```text
 Caption "Step 1: prepare the review frame"
 Hide
@@ -135,4 +143,4 @@ terminal is already stable and only the caption changed, add `Sleep` after `Capt
 video outputs hold that caption for a visible amount of time.
 
 Captions render on visual outputs: GIF, PNG, MP4, WebM, frame directories, and screenshots. They do
-not appear in state JSON.
+not appear in state JSON or change final output dimensions.

--- a/site/src/content/docs/examples.mdx
+++ b/site/src/content/docs/examples.mdx
@@ -18,23 +18,24 @@ also live under `site/public/assets` with Git LFS. See
 
 ## Example Index
 
-| Tape                                      | Demonstrates                                    | Useful docs                                                            |
-| ----------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
-| [`quick-start.tape`][quick-start-src]     | installing, help, `new`, and nested `run`       | [Quick Start](../quick-start/)                                         |
-| [`basic.tape`][basic-src]                 | typing, waits, theme, window bar, border radius | [Tape files](../authoring/tape-files/), [themes](../authoring/themes/) |
-| [`hide-show.tape`][hide-show-src]         | hidden setup and hidden trailing cleanup        | [Hidden work](../authoring/tape-files/#hidden-work)                    |
-| [`waits.tape`][waits-src]                 | line, screen, regex, and default prompt waits   | [Wait commands](../reference/tape-reference/#waitduration-regextext)   |
-| [`keys.tape`][keys-src]                   | key commands, repeats, editing, and interrupt   | [Key commands](../reference/tape-reference/#key-commands)              |
-| [keyboard-overlay][keyboard-overlay-src]  | input labels over review media                  | [Keyboard overlay](../reference/tape-reference/#settings)              |
-| [`clipboard-env.tape`][clipboard-env-src] | `Env`, `Copy`, and `Paste`                      | [Tape reference](../reference/tape-reference/#copy-text-and-paste)     |
-| [`captions.tape`][captions-src]           | visual captions for review media                | [Caption command](../reference/tape-reference/#caption-text)           |
-| [`outputs.tape`][outputs-src]             | GIF, PNG, JSON, screenshot, state, frame dir    | [Outputs](../authoring/outputs/)                                       |
-| [`scrollback.tape`][scrollback-src]       | scrollback-inclusive state JSON                 | [State JSON](../testing/state-json/)                                   |
-| [`text-styles.tape`][text-styles-src]     | ANSI styles, truecolor, and styled state spans  | [State JSON](../testing/state-json/#styles-and-spans)                  |
-| [`layout.tape`][layout-src]               | padding, margin, fill, window bar, radius       | [Themes and styling](../authoring/themes/)                             |
-| [`themes.tape`][themes-src]               | copied Ghostty themes and palette mapping       | [Theme lookup](../authoring/themes/#theme-lookup)                      |
-| [`screenshot.tape`][screenshot-src]       | screenshots and terminal state JSON             | [Checkpoints](../authoring/outputs/#checkpoints)                       |
-| [`video.tape`][video-src]                 | GIF, MP4, and WebM from one capture             | [Video encoding](../authoring/outputs/#video-encoding)                 |
+| Tape                                                      | Demonstrates                                    | Useful docs                                                            |
+| --------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------- |
+| [`quick-start.tape`][quick-start-src]                     | installing, help, `new`, and nested `run`       | [Quick Start](../quick-start/)                                         |
+| [`basic.tape`][basic-src]                                 | typing, waits, theme, window bar, border radius | [Tape files](../authoring/tape-files/), [themes](../authoring/themes/) |
+| [`hide-show.tape`][hide-show-src]                         | hidden setup and hidden trailing cleanup        | [Hidden work](../authoring/tape-files/#hidden-work)                    |
+| [`waits.tape`][waits-src]                                 | line, screen, regex, and default prompt waits   | [Wait commands](../reference/tape-reference/#waitduration-regextext)   |
+| [`keys.tape`][keys-src]                                   | key commands, repeats, editing, and interrupt   | [Key commands](../reference/tape-reference/#key-commands)              |
+| [keyboard-overlay][keyboard-overlay-src]                  | input labels over review media                  | [Keyboard overlay](../reference/tape-reference/#settings)              |
+| [`clipboard-env.tape`][clipboard-env-src]                 | `Env`, `Copy`, and `Paste`                      | [Tape reference](../reference/tape-reference/#copy-text-and-paste)     |
+| [`captions.tape`][captions-src]                           | visual captions for review media                | [Caption command](../reference/tape-reference/#caption-text)           |
+| [`presentation-overlays.tape`][presentation-overlays-src] | captions plus keyboard overlay layout           | [Captions](../authoring/outputs/#captions)                             |
+| [`outputs.tape`][outputs-src]                             | GIF, PNG, JSON, screenshot, state, frame dir    | [Outputs](../authoring/outputs/)                                       |
+| [`scrollback.tape`][scrollback-src]                       | scrollback-inclusive state JSON                 | [State JSON](../testing/state-json/)                                   |
+| [`text-styles.tape`][text-styles-src]                     | ANSI styles, truecolor, and styled state spans  | [State JSON](../testing/state-json/#styles-and-spans)                  |
+| [`layout.tape`][layout-src]                               | padding, margin, fill, window bar, radius       | [Themes and styling](../authoring/themes/)                             |
+| [`themes.tape`][themes-src]                               | copied Ghostty themes and palette mapping       | [Theme lookup](../authoring/themes/#theme-lookup)                      |
+| [`screenshot.tape`][screenshot-src]                       | screenshots and terminal state JSON             | [Checkpoints](../authoring/outputs/#checkpoints)                       |
+| [`video.tape`][video-src]                                 | GIF, MP4, and WebM from one capture             | [Video encoding](../authoring/outputs/#video-encoding)                 |
 
 ## Preview GIFs
 
@@ -66,7 +67,8 @@ updates terminal state, but the animation starts only when `Show` reveals the pr
 ![Captioned Betamax GIF](/betamax/assets/betamax-captions.gif)
 
 `captions.tape` annotates rendered media without changing the terminal session. Caption changes are
-presentation metadata: waits and state outputs keep matching the terminal itself.
+presentation metadata: waits and state outputs keep matching the terminal itself. Captions render in
+a reserved presentation row below the terminal canvas.
 
 ### Keyboard Overlay
 
@@ -75,6 +77,11 @@ presentation metadata: waits and state outputs keep matching the terminal itself
 `keyboard-overlay.tape` shows typed commands and key presses as compact labels over generated media.
 Labels appear when input is queued and linger briefly after typing, which keeps review GIFs readable
 without turning the overlay into a permanent command log.
+
+`presentation-overlays.tape` combines captions and keyboard overlay chips. The caption is
+left-aligned with the terminal frame, key chips are right-aligned, and long captions are truncated
+with `...` rather than wrapped over the chips. Caption glyphs are clipped to their reserved width as
+a final guard for font fallback and unusually wide characters.
 
 ### Themes
 
@@ -111,6 +118,7 @@ Use `examples/waits.tape` when debugging timing. It shows the three wait targets
 [keys-src]: https://github.com/joshka/betamax/blob/main/examples/keys.tape
 [layout-src]: https://github.com/joshka/betamax/blob/main/examples/layout.tape
 [outputs-src]: https://github.com/joshka/betamax/blob/main/examples/outputs.tape
+[presentation-overlays-src]: https://github.com/joshka/betamax/blob/main/examples/presentation-overlays.tape
 [quick-start-src]: https://github.com/joshka/betamax/blob/main/examples/quick-start.tape
 [screenshot-src]: https://github.com/joshka/betamax/blob/main/examples/screenshot.tape
 [scrollback-src]: https://github.com/joshka/betamax/blob/main/examples/scrollback.tape

--- a/site/src/content/docs/overview.mdx
+++ b/site/src/content/docs/overview.mdx
@@ -35,6 +35,10 @@ Final [`Output`][output-command] artifacts are written after the tape finishes.
 [`Screenshot`][screenshot-command] and [`State`][state-command] commands write checkpoint artifacts
 at their position in the tape.
 
+Captions and keyboard overlays are presentation-only media annotations. They are drawn into a
+reserved row below the terminal canvas for visual outputs, so review labels can explain a workflow
+without covering terminal content or changing state JSON.
+
 ## Tape Model
 
 Most tapes have the same shape:

--- a/site/src/content/docs/reference/tape-reference.mdx
+++ b/site/src/content/docs/reference/tape-reference.mdx
@@ -62,7 +62,7 @@ an error rather than a quiet fallback.
 | `PlaybackSpeed` | number                | `1.0`            | Output playback multiplier; does not speed up command execution       |
 | `LoopOffset`    | number or percentage  | `0.0`            | Rotates animated output frames to move the loop boundary              |
 | `CursorBlink`   | bool                  | `true`           | Simulates cursor blink in captured frames                             |
-| KeyboardOverlay | enum                  | `Off`            | Draws recent input over generated media                               |
+| KeyboardOverlay | enum                  | `Off`            | Shows recent input chips in media                                     |
 | `WaitTimeout`   | duration or number    | `15s`            | Default timeout for wait commands; bare numbers are seconds           |
 | `WaitPattern`   | regex string          | `>$`             | Regex used by bare `Wait`                                             |
 | `Margin`        | number                | `0`              | Outer decoration margin in pixels                                     |
@@ -71,20 +71,23 @@ an error rather than a quiet fallback.
 | `WindowBarSize` | number                | `30`             | Window bar height in pixels                                           |
 | `BorderRadius`  | number                | `0`              | Rounded-corner mask radius in pixels                                  |
 
-The terminal grid is derived after all settings are applied. Margin and window-bar decoration are
-subtracted from width and height first, then padding, font size, letter spacing, and line height
-determine the PTY columns and rows. Extremely small dimensions are clamped to at least one row and
-one column.
+The terminal grid is derived after all settings are applied. Margin, window-bar decoration, and any
+presentation row needed for captions or keyboard overlay are subtracted from width and height first,
+then padding, font size, letter spacing, and line height determine the PTY columns and rows.
+Extremely small dimensions are clamped to at least one row and one column.
 
 Treat larger `FontSize`, larger `Margin`, and decorative frame settings as presentation zoom. When
 the tape is proving modal placement, centered content, wrapping, or split-pane layout, prefer the
 default `FontSize`, default `Margin`, and a wider `Width` or `Height` so the proof matches the
 application layout rather than the demo framing.
 
-`Set KeyboardOverlay Input` draws a compact time-aware input HUD over generated PNG, GIF, video,
+`Set KeyboardOverlay Input` draws compact time-aware input chips on generated PNG, GIF, video,
 screenshot, and frame-sequence media. Labels appear when input is queued and linger briefly after
 the input is typed, so review GIFs show the action near the terminal change it caused. The overlay
-is presentation-only: it does not change PTY input bytes, terminal dimensions, waits, or state JSON.
+is presentation-only: it does not change PTY input bytes, waits, state JSON, or final output
+dimensions. When enabled, Betamax reserves a bottom presentation row before deriving the terminal
+grid so chips do not cover terminal content. Keyboard chips are right-aligned to the terminal frame
+edge and share the row with captions when both are active.
 
 Keyboard overlay modes are:
 
@@ -191,16 +194,22 @@ Sets a caption rendered onto later visual media frames. The text is one token, s
 that contain spaces. Use `Caption ""` to clear the active caption.
 
 Captions are presentation metadata only. They do not write to the PTY, alter terminal state, affect
-wait matching, or change output dimensions. Active captions appear on GIF, PNG, MP4, WebM, frame
-directory, and `Screenshot` outputs. `State` JSON does not include captions.
+wait matching, or change final output dimensions. Active captions appear on GIF, PNG, MP4, WebM,
+frame directory, and `Screenshot` outputs. `State` JSON does not include captions. When a tape
+contains a caption, Betamax reserves a bottom presentation row before deriving the terminal grid so
+captions do not cover terminal content.
 
 `Caption` does not capture a frame or add time to animated output by itself. The new caption appears
 on the next visual frame Betamax renders, such as a frame captured during a later `Sleep`, `Wait`,
 typing, key press, `Show`, final-frame output, or `Screenshot`. Add `Sleep` after a caption-only
 change when an animation should dwell on the new caption without changing terminal content.
 
-Betamax renders captions as a bottom overlay. If the overlay covers important terminal content,
-increase the tape height, margin, or padding, or clear the caption before the affected frame.
+Betamax renders captions below the terminal canvas, left-aligned with the terminal frame edge.
+Captions are single-line presentation text: if a caption does not fit beside right-aligned keyboard
+chips, Betamax truncates it with `...` instead of wrapping. Caption glyphs are clipped to their
+reserved width as a final guard for font fallback and unusually wide characters. If the caption or
+keyboard overlay needs more room, increase the tape height or reduce presentation chrome such as
+margin and window bar size.
 
 ### `Screenshot <path>.png`
 


### PR DESCRIPTION
## Summary

- reserve a presentation row for captions and keyboard overlay chips so they do not cover terminal content
- align captions to the terminal frame left edge and keyboard chips to the right edge on the same row
- truncate captions with `...` using shaped text width, with clipping as a final guard
- document the overlay behavior in source docs and website docs, and add a combined caption/keyboard example tape

## Validation

- `mise run test`
- `mise run clippy`
- `mise run validate`
- `mise run lint-md`
- `mise run docs-site-check`
- `mise run docs-site-build`
- `cargo run -p betamax -- run examples/presentation-overlays.tape`
