### PR TITLE
Expose media authoring docs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -47,7 +47,9 @@ export default defineConfig({
           label: 'Authoring',
           items: [
             { label: 'Tape Files', slug: 'authoring/tape-files' },
+            { label: 'Input And Keys', slug: 'authoring/input-and-keys' },
             { label: 'Outputs', slug: 'authoring/outputs' },
+            { label: 'Presentation Overlays', slug: 'authoring/presentation-overlays' },
             { label: 'Generated Media Storage', slug: 'authoring/generated-media' },
             { label: 'Themes And Styling', slug: 'authoring/themes' },
           ],

--- a/site/src/content/docs/authoring/input-and-keys.mdx
+++ b/site/src/content/docs/authoring/input-and-keys.mdx
@@ -1,0 +1,92 @@
+---
+title: Input And Keys
+description: Type printable text, press terminal control keys, and show input in review media.
+---
+
+Betamax tapes drive a real PTY with printable text and terminal key sequences. Use `Type` for text
+the user would enter, and use key commands for navigation, editing, shortcuts, and interrupts.
+
+## Printable Text
+
+[`Type`](../../reference/tape-reference/#typeduration-text) sends text into the terminal one
+Unicode scalar at a time. The default delay comes from `Set TypingSpeed`, and a command can override
+that delay with an `@duration` suffix.
+
+```text
+Set TypingSpeed 30ms
+
+Type "printf 'hello from betamax\n'"
+Enter
+Wait+Screen "hello from betamax"
+
+Type@5ms "fast input for a long fixture"
+Enter
+```
+
+Quote text that contains spaces, shell syntax, newlines, or backslashes. `Type` is for printable
+text; use key commands when the input should be a terminal control key.
+
+## Key Commands
+
+Key commands send encoded key sequences through the terminal. They can include modifiers, an
+optional duration, and an optional repeat count.
+
+```text
+Type "abcdef"
+Left 3
+Backspace
+Delete
+End
+Enter
+
+Ctrl+C
+Shift+Tab
+Alt+F
+F5
+```
+
+Use keys for cursor movement, readline editing, interrupting commands, menu navigation, and TUI
+shortcuts. The reference lists the supported named keys and modifier syntax in
+[Key Commands](../../reference/tape-reference/#key-commands).
+
+## Editing And Interrupts
+
+The `examples/keys.tape` example is a compact smoke test for editing and terminal control keys. It
+types text, moves the cursor, deletes characters, submits the edited line, interrupts a command
+with `Ctrl+C`, and waits for the shell prompt before continuing.
+
+```text
+Type "abcdef"
+Left 3
+Backspace
+Delete
+End
+Enter
+Wait+Screen "edited=abef"
+
+Type "sleep 5"
+Ctrl+C
+Wait
+```
+
+Prefer a semantic `Wait`, `Wait+Line`, or `Wait+Screen` after input that changes terminal state.
+That keeps tapes tied to observed behavior instead of fixed delays.
+
+## On-Screen Keys
+
+Use [`KeyboardOverlay`](../presentation-overlays/#keyboard-overlays) when generated media should
+show the input that caused a terminal change. The overlay is useful for review GIFs and screenshots
+because arrow keys, shortcuts, and interrupts are otherwise invisible.
+
+```text
+Set KeyboardOverlay Input
+Set KeyboardOverlayLocation BottomRight
+
+Type "echo foo"
+Enter
+Wait+Screen "foo"
+Sleep 900ms
+```
+
+The overlay is presentation-only. It does not change the bytes written to the PTY, wait matching,
+state JSON, or final output dimensions.

--- a/site/src/content/docs/authoring/outputs.mdx
+++ b/site/src/content/docs/authoring/outputs.mdx
@@ -30,9 +30,9 @@ Use GIF for documentation and release notes. Use PNG screenshots when a human ne
 single stable state. Use state JSON when a test should compare text, scrollback, cursor metadata,
 and styles without doing pixel comparisons.
 
-Use [`Caption`](../../reference/tape-reference/#caption-text) when generated visual media should
-explain a workflow step or review checkpoint without changing terminal behavior. Captions render on
-visual outputs only; they do not appear in state JSON. Captions share a bottom presentation row with
+Use [Presentation Overlays](../presentation-overlays/) when generated visual media should explain a
+workflow step or review checkpoint without changing terminal behavior. Captions render on visual
+outputs only; they do not appear in state JSON. Captions share a bottom presentation row with
 keyboard overlay chips when both are active.
 
 Frame directories are useful when debugging capture timing or feeding rendered frames to custom
@@ -106,8 +106,9 @@ text and styles in a compact comparison format.
 ## Captions
 
 Captions annotate rendered media without changing the terminal session. They are useful when a GIF
-or screenshot needs to explain hidden setup, a review checkpoint, or a step in a TUI flow. Keep
-semantic checks in waits and state outputs; captions are presentation metadata.
+or screenshot needs to explain hidden setup, a review checkpoint, or a step in a TUI flow. See
+[Presentation Overlays](../presentation-overlays/) for keyboard chips and placement tradeoffs.
+Keep semantic checks in waits and state outputs; captions are presentation metadata.
 
 When a tape uses captions, Betamax reserves a bottom presentation row before deriving the terminal
 grid. Captions render below the terminal canvas instead of covering terminal rows. They are

--- a/site/src/content/docs/authoring/presentation-overlays.mdx
+++ b/site/src/content/docs/authoring/presentation-overlays.mdx
@@ -1,0 +1,101 @@
+---
+title: Presentation Overlays
+description: Add captions and keyboard chips to visual terminal media.
+---
+
+Presentation overlays annotate generated media without changing the terminal session. They are for
+human review: explaining a step, revealing invisible input, or making a GIF understandable without
+turning those annotations into test state.
+
+## Captions
+
+[`Caption`](../../reference/tape-reference/#caption-text) sets single-line text drawn onto later
+visual frames. Captions render on GIF, PNG, MP4, WebM, frame directory, and `Screenshot` outputs.
+They do not appear in state JSON, affect waits, or write to the PTY.
+
+```text
+Caption "Step 1: prepare the review frame"
+Hide
+Type "my-app --demo"
+Enter
+Wait+Screen "Ready"
+Show
+Sleep 700ms
+
+Caption "Step 2: capture the ready state"
+Screenshot target/snapshots/ready.png
+State target/snapshots/ready.json
+
+Caption ""
+Sleep 300ms
+```
+
+`Caption` has no duration and does not capture a frame by itself. It changes the active caption for
+the next visual frame captured by a later `Sleep`, `Wait`, typed character, key press, `Show`, final
+output, or `Screenshot`. Add a short `Sleep` after a caption-only change when an animation should
+hold the new label.
+
+Use `Caption ""` before later frames that should not have a caption.
+
+## Keyboard Overlays
+
+`Set KeyboardOverlay Input` draws compact input chips on generated visual media. Labels appear when
+input is queued and linger briefly after the input is typed, so a review GIF can show the action
+near the terminal change it caused.
+
+```text
+Set KeyboardOverlay Input
+Set KeyboardOverlayLocation CaptionRow
+
+Caption "Keyboard chips identify invisible input"
+Type "echo foo"
+Enter
+Wait+Screen "foo"
+Sleep 900ms
+
+Ctrl+C
+Wait
+Sleep 500ms
+```
+
+Keyboard overlay modes are:
+
+- `Off`: no overlay.
+- `Keys`: explicit key commands only, such as `Ctrl+P`, `Down`, `Enter`, and `Escape`.
+- `Input`: key commands plus short typed input that reads like user intent.
+- `All`: every visible input event, including long `Type` commands summarized by character count.
+
+See the [settings reference](../../reference/tape-reference/#settings) for exact setting names and
+defaults.
+
+## Overlay Placement
+
+`KeyboardOverlayLocation CaptionRow` reserves a bottom presentation row before Betamax derives the
+terminal grid. Captions are left-aligned in that row and key chips are right-aligned, so overlays do
+not cover terminal content.
+
+Corner locations such as `BottomRight`, `BottomLeft`, `TopRight`, and `TopLeft` draw chips inside
+the terminal canvas with a small inset from the terminal edge. Corner overlays are useful when the
+terminal dimensions must stay unchanged, but they can cover terminal cells.
+
+## Layout Tradeoffs
+
+Captions and caption-row keyboard chips reserve presentation space before the PTY size is computed.
+If a tape proves modal placement, centering, wrapping, or split-pane behavior, verify the terminal
+grid still matches the layout being tested.
+
+Long captions stay single-line. When a caption shares space with right-aligned keyboard chips,
+Betamax truncates the caption with `...` instead of wrapping over the chips. Increase `Height`,
+reduce `FontSize`, or move keyboard chips to a corner location when the presentation row needs more
+room.
+
+## Examples
+
+- [`captions.tape`][captions-src] shows caption-only annotation.
+- [`keyboard-overlay.tape`][keyboard-overlay-src] shows typed input and key presses as chips.
+- [`presentation-overlays.tape`][presentation-overlays-src] combines captions with caption-row
+  keyboard chips.
+
+[captions-src]: https://github.com/joshka/betamax/blob/main/examples/captions.tape
+[keyboard-overlay-src]: https://github.com/joshka/betamax/blob/main/examples/keyboard-overlay.tape
+[presentation-overlays-src]: https://github.com/joshka/betamax/blob/main/examples/presentation-overlays.tape

--- a/site/src/content/docs/examples.mdx
+++ b/site/src/content/docs/examples.mdx
@@ -24,11 +24,11 @@ also live under `site/public/assets` with Git LFS. See
 | [`basic.tape`][basic-src]                                 | typing, waits, theme, window bar, border radius | [Tape files](../authoring/tape-files/), [themes](../authoring/themes/) |
 | [`hide-show.tape`][hide-show-src]                         | hidden setup and hidden trailing cleanup        | [Hidden work](../authoring/tape-files/#hidden-work)                    |
 | [`waits.tape`][waits-src]                                 | line, screen, regex, and default prompt waits   | [Wait commands](../reference/tape-reference/#waitduration-regextext)   |
-| [`keys.tape`][keys-src]                                   | key commands, repeats, editing, and interrupt   | [Key commands](../reference/tape-reference/#key-commands)              |
-| [keyboard-overlay][keyboard-overlay-src]                  | input labels over review media                  | [Keyboard overlay](../reference/tape-reference/#settings)              |
+| [`keys.tape`][keys-src]                                   | key commands, repeats, editing, and interrupt   | [Input and keys](../authoring/input-and-keys/)                         |
+| [keyboard-overlay][keyboard-overlay-src]                  | input labels over review media                  | [Presentation overlays](../authoring/presentation-overlays/)           |
 | [`clipboard-env.tape`][clipboard-env-src]                 | `Env`, `Copy`, and `Paste`                      | [Tape reference](../reference/tape-reference/#copy-text-and-paste)     |
-| [`captions.tape`][captions-src]                           | visual captions for review media                | [Caption command](../reference/tape-reference/#caption-text)           |
-| [`presentation-overlays.tape`][presentation-overlays-src] | captions plus keyboard overlay layout           | [Captions](../authoring/outputs/#captions)                             |
+| [`captions.tape`][captions-src]                           | visual captions for review media                | [Presentation overlays](../authoring/presentation-overlays/)           |
+| [`presentation-overlays.tape`][presentation-overlays-src] | captions plus keyboard overlay layout           | [Presentation overlays](../authoring/presentation-overlays/)           |
 | [`outputs.tape`][outputs-src]                             | GIF, PNG, JSON, screenshot, state, frame dir    | [Outputs](../authoring/outputs/)                                       |
 | [`scrollback.tape`][scrollback-src]                       | scrollback-inclusive state JSON                 | [State JSON](../testing/state-json/)                                   |
 | [`text-styles.tape`][text-styles-src]                     | ANSI styles, truecolor, and styled state spans  | [State JSON](../testing/state-json/#styles-and-spans)                  |
@@ -75,6 +75,7 @@ a reserved presentation row below the terminal canvas.
 ![Keyboard overlay Betamax GIF](/betamax/assets/betamax-keyboard-overlay.gif)
 
 `keyboard-overlay.tape` shows typed commands and key presses as compact labels over generated media.
+See [Presentation Overlays](../authoring/presentation-overlays/) for overlay modes and placement.
 Labels appear when input is queued and linger briefly after typing, which keeps review GIFs readable
 without turning the overlay into a permanent command log.
 

--- a/site/src/content/docs/overview.mdx
+++ b/site/src/content/docs/overview.mdx
@@ -35,9 +35,9 @@ Final [`Output`][output-command] artifacts are written after the tape finishes.
 [`Screenshot`][screenshot-command] and [`State`][state-command] commands write checkpoint artifacts
 at their position in the tape.
 
-Captions and keyboard overlays are presentation-only media annotations. They are drawn into a
-reserved row below the terminal canvas for visual outputs, so review labels can explain a workflow
-without covering terminal content or changing state JSON.
+Captions and keyboard overlays are presentation-only media annotations. [Presentation
+Overlays][presentation-overlays] covers captions, on-screen key chips, and placement tradeoffs for
+visual outputs, so review labels can explain a workflow without changing state JSON.
 
 ## Tape Model
 
@@ -58,8 +58,9 @@ condition.
 ## Documentation Captures
 
 [Quick Start][quick-start] covers installation and the first rendered tape. [Tape Files][tape-files]
-explains tape structure, tokenization, waits, hidden work, outputs, and shell defaults.
-[Examples][examples] maps each checked-in tape to the behavior it demonstrates.
+explains tape structure, tokenization, waits, hidden work, outputs, and shell defaults. [Input And
+Keys][input-and-keys] covers printable text, navigation keys, shortcuts, interrupts, and on-screen
+key overlays. [Examples][examples] maps each checked-in tape to the behavior it demonstrates.
 
 [Generated Media Storage][generated-media] covers where rendered files belong when a repository
 needs stable README media, review artifacts, CI outputs, or web-hosted documentation assets.
@@ -95,6 +96,8 @@ external encoder.
 ## Next Pages
 
 - [Quick Start][quick-start] installs Betamax and renders a first tape.
+- [Input And Keys][input-and-keys] explains typing, key commands, and visible input chips.
+- [Presentation Overlays][presentation-overlays] explains captions and on-screen key labels.
 - [Examples][examples] shows each checked-in tape and the behavior it demonstrates.
 - [Tape Reference][tape-reference] documents every command, setting, default, and CLI option.
 - [Differences From VHS][vhs-differences] explains compatibility boundaries for users familiar
@@ -104,8 +107,10 @@ external encoder.
 [examples]: ../examples/
 [generated-media]: ../authoring/generated-media/
 [env-command]: ../reference/tape-reference/#env-key-value
+[input-and-keys]: ../authoring/input-and-keys/
 [outputs]: ../authoring/outputs/
 [output-command]: ../reference/tape-reference/#output-path
+[presentation-overlays]: ../authoring/presentation-overlays/
 [quick-start]: ../quick-start/
 [require-command]: ../reference/tape-reference/#require-program
 [screenshot-command]: ../reference/tape-reference/#screenshot-pathpng


### PR DESCRIPTION
## Summary

- Add first-class Authoring docs for input/key commands and presentation overlays.
- Expose those pages in the Starlight sidebar so captions and on-screen keys are discoverable.
- Update overview, examples, and outputs docs to route readers to the new feature pages.

## Validation

- `mise run lint-md`
- `mise run docs-site-check`
- `mise run docs-site-build`
